### PR TITLE
Rename module references to MMM-ScoresAndStandings

### DIFF
--- a/MMM-ScoresAndStandings.css
+++ b/MMM-ScoresAndStandings.css
@@ -1,4 +1,4 @@
-/* MMM-MLBScoresAndStandings.css */
+/* MMM-ScoresAndStandings.css */
 
 /*--------------------------------------------------
   GLOBAL VARIABLES (easy tweaking)

--- a/MMM-ScoresAndStandings.js
+++ b/MMM-ScoresAndStandings.js
@@ -1,4 +1,4 @@
-/* MMM-MLBScoresAndStandings.js */
+/* MMM-ScoresAndStandings.js */
 /* global Module */
 
 (function () {
@@ -37,7 +37,7 @@
     "NL": "NL Wild Card", "AL": "AL Wild Card"
   };
 
-  Module.register("MMM-MLBScoresAndStandings", {
+  Module.register("MMM-ScoresAndStandings", {
     defaults: {
       updateIntervalScores:            60 * 1000,
       updateIntervalStandings:       15 * 60 * 1000,
@@ -80,7 +80,7 @@
     },
 
     getStyles: function () {
-      return ["MMM-MLBScoresAndStandings.css"];
+      return ["MMM-ScoresAndStandings.css"];
     },
 
     start: function () {
@@ -223,7 +223,7 @@
           this.updateDom();
         }
       } catch (e) {
-        console.error("MMM-MLBScoresAndStandings: socket handler error", e);
+        console.error("MMM-ScoresAndStandings: socket handler error", e);
       }
     },
 
@@ -265,7 +265,7 @@
       try {
         wrapper.appendChild(showingGames ? this._buildGames() : this._buildStandings());
       } catch (e) {
-        console.error("MMM-MLBScoresAndStandings: getDom build error", e);
+        console.error("MMM-ScoresAndStandings: getDom build error", e);
         return this._noData("Error building view.");
       }
       return wrapper;

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MMM-MLBScoresAndStandings
+# MMM-ScoresAndStandings
 
 A sleek MLB scoreboard + standings module for [MagicMirror²](https://magicmirror.builders) that now supports NHL and NFL scoreboards.
 It rotates between game scoreboards and standings (division pairs and wild cards), supports team highlighting, compact layouts, and highly tunable fonts/sizing via CSS variables.
@@ -60,8 +60,8 @@ Rotation timing for each screen is configurable.
 
 ```bash
 cd ~/MagicMirror/modules
-git clone https://github.com/yourname/MMM-MLBScoresAndStandings.git
-cd MMM-MLBScoresAndStandings
+git clone https://github.com/yourname/MMM-ScoresAndStandings.git
+cd MMM-ScoresAndStandings
 # No npm install required (uses global.fetch from Node 18+)
 ```
 
@@ -77,7 +77,7 @@ Add to your `config/config.js`:
 
 ```js
 {
-  module: "MMM-MLBScoresAndStandings",
+  module: "MMM-ScoresAndStandings",
   position: "middle_center", // or wherever you prefer
   config: {
     // Refresh
@@ -132,10 +132,10 @@ Add to your `config/config.js`:
 ## Images & Fonts
 
 ```
-MMM-MLBScoresAndStandings/
-├─ MMM-MLBScoresAndStandings.js
+MMM-ScoresAndStandings/
+├─ MMM-ScoresAndStandings.js
 ├─ node_helper.js
-├─ MMM-MLBScoresAndStandings.css
+├─ MMM-ScoresAndStandings.css
 ├─ fonts/
 │  └─ TimesSquare-m105.ttf
 └─ images/
@@ -154,7 +154,7 @@ MMM-MLBScoresAndStandings/
 
 ## Styling & CSS Variables
 
-Most sizing is controlled by CSS variables in `MMM-MLBScoresAndStandings.css`.
+Most sizing is controlled by CSS variables in `MMM-ScoresAndStandings.css`.
 You now have two ways to rein in the layout when it feels oversized:
 
 1. **Quick fix** – use the `layoutScale` config option (or override `--box-scale`) to shrink or enlarge everything uniformly.
@@ -193,7 +193,7 @@ Example override (drop into your `css/custom.css`):
 **Header font switched to Times Square**  
 Remove any global rules like:
 ```css
-.module.MMM-MLBScoresAndStandings * { font-family: 'Times Square' !important; }
+.module.MMM-ScoresAndStandings * { font-family: 'Times Square' !important; }
 ```
 and use the header override shown above.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "MMM-MLBScoresAndStandings",
+  "name": "MMM-ScoresAndStandings",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "MMM-MLBScoresAndStandings",
+      "name": "MMM-ScoresAndStandings",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,19 +1,19 @@
 {
-  "name": "MMM-MLBScoresAndStandings",
+  "name": "MMM-ScoresAndStandings",
   "version": "1.0.0",
   "description": "MagicMirror module to display today's MLB games and current standings",
-  "main": "MMM-MLBScoresAndStandings.js",
+  "main": "MMM-ScoresAndStandings.js",
   "scripts": {},
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mrjrask/MMM-MLBScoresAndStandings.git"
+    "url": "git+https://github.com/mrjrask/MMM-ScoresAndStandings.git"
   },
   "author": "mrjrask & ChatGPT",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/mrjrask/MMM-MLBScoresAndStandings/issues"
+    "url": "https://github.com/mrjrask/MMM-ScoresAndStandings/issues"
   },
-  "homepage": "https://github.com/mrjrask/MMM-MLBScoresAndStandings#readme",
+  "homepage": "https://github.com/mrjrask/MMM-ScoresAndStandings#readme",
   "dependencies": {
     "moment": "^2.29.0"
   }


### PR DESCRIPTION
## Summary
- update module registration, styles, and console messages to use the new MMM-ScoresAndStandings identifier
- refresh documentation and package metadata to point to the renamed module

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d89791fb888322b3888c2df5c40ff3