### PR TITLE
Enable multi-league scoreboard rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It rotates between game scoreboards and standings (division pairs and wild cards
 ## Features
 
 - **Scoreboard** uses a fixed 4 × 3 grid (12 slots) per page.
-- **Multi-league support**: MLB (scoreboard + standings), NHL (goals & shots on goal), NFL (quarter-by-quarter with totals).
+- **Multi-league support**: MLB (scoreboard + standings), NHL (goals & shots on goal), NFL (quarter-by-quarter with totals) — rotate one module through several leagues or pin each league to its own instance.
 - **Standings** cycle: NL/AL East, NL/AL Central, NL/AL West, NL Wild Card, AL Wild Card.
 - **Wild Card**: division leaders are excluded; WCGB computed vs. the 3rd WC team.
 - **“GB / WCGB / E#”**: `0` rendered as `--`; half-games show as `1/2` in smaller type.
@@ -84,7 +84,8 @@ Add to your `config/config.js`:
     updateIntervalScores: 60 * 1000,
     updateIntervalStandings: 15 * 60 * 1000,
 
-    league: "mlb",             // "mlb", "nhl", or "nfl"
+    league: "mlb",             // default / primary league ("mlb", "nhl", or "nfl")
+    leagues: ["mlb", "nhl"],   // optional scoreboard rotation order
 
     // Scoreboard layout
     scoreboardColumns: 2,     // number of columns of game boxes per page
@@ -115,8 +116,26 @@ Add to your `config/config.js`:
 }
 ```
 
+To show multiple leagues simultaneously, duplicate the module definition with a
+different `league` value for each instance:
+
+```js
+{
+  module: "MMM-ScoresAndStandings",
+  position: "top_left",
+  config: { league: "mlb" }
+},
+{
+  module: "MMM-ScoresAndStandings",
+  position: "bottom_left",
+  config: { league: "nhl" }
+}
+```
+
 **Notes**
-- **League**: set `league` to `"nhl"` or `"nfl"` for hockey or football scoreboards (standings are MLB-only).
+- **League**: `league` remains the fallback/primary sport when `leagues` isn’t supplied.
+- **Scoreboard rotation**: set `leagues: ["mlb", "nhl", "nfl"]` (any subset) to rotate the scoreboard through each sport before the standings. The first entry (or `league` when omitted) is treated as the primary league, and MLB standings only appear when `"mlb"` is included.
+- **Multiple module instances**: add another `MMM-ScoresAndStandings` entry in `config.js` for each league you want to display. Each instance runs independently, so you can pin MLB to one region and NHL/NFL to another without extra setup.
 - **Header width** matches `maxWidth` and stays in the default MM font (Roboto Condensed).
 - **Highlighted teams** accept a single string `"CUBS"` or an array like `["CUBS","NYY"]`.
 - **layoutScale** is the quickest way to fix oversize boxes—values below `1` compact the layout.

--- a/node_helper.js
+++ b/node_helper.js
@@ -2,43 +2,66 @@
 const NodeHelper = require("node_helper");
 const fetch      = global.fetch;
 
+const SUPPORTED_LEAGUES = ["mlb", "nhl", "nfl"];
+
 module.exports = NodeHelper.create({
   start() {
     console.log("🛰️ MMM-ScoresAndStandings helper started");
+    this.scoreIntervals = {};
+    this.standInterval = null;
   },
 
   socketNotificationReceived(notification, payload) {
     if (notification === "INIT") {
       this.config = payload || {};
-      this.league = this._getLeague();
+      this.leagues = this._getLeagues();
+      this.league = this.leagues[0] || "mlb";
 
-      this._fetchGames();
-      if (this.league === "mlb") {
-        this._fetchStandings();
-      } else {
-        // Immediately clear out any previous standings on the front-end
-        this.sendSocketNotification("STANDINGS", []);
-      }
+      this._clearIntervals();
 
       const scoreInterval = Math.max(10 * 1000, this.config.updateIntervalScores || (60 * 1000));
-      setInterval(() => this._fetchGames(), scoreInterval);
+      for (const league of this.leagues) {
+        this._fetchGamesForLeague(league);
+        this.scoreIntervals[league] = setInterval(() => this._fetchGamesForLeague(league), scoreInterval);
+      }
 
-      if (this.league === "mlb") {
+      if (this.leagues.includes("mlb")) {
+        this._fetchStandings();
         const standInterval = Math.max(60 * 1000, this.config.updateIntervalStandings || (15 * 60 * 1000));
-        setInterval(() => this._fetchStandings(), standInterval);
+        this.standInterval = setInterval(() => this._fetchStandings(), standInterval);
+      } else {
+        this.sendSocketNotification("STANDINGS", []);
       }
     }
   },
 
+  _clearIntervals() {
+    if (this.scoreIntervals) {
+      for (const key of Object.keys(this.scoreIntervals)) {
+        clearInterval(this.scoreIntervals[key]);
+      }
+    }
+    this.scoreIntervals = {};
+    if (this.standInterval) {
+      clearInterval(this.standInterval);
+      this.standInterval = null;
+    }
+  },
+
   async _fetchGames() {
-    const league = this._getLeague();
-    if (league === "nhl") return this._fetchNhlGames();
-    if (league === "nfl") return this._fetchNflGames();
+    return this._fetchGamesForLeague(this._getLeague());
+  },
+
+  async _fetchGamesForLeague(league) {
+    const sanitized = this._sanitizeLeague(league) || "mlb";
+    if (sanitized === "nhl") return this._fetchNhlGames();
+    if (sanitized === "nfl") return this._fetchNflGames();
     return this._fetchMlbGames();
   },
 
   async _fetchStandings() {
-    if (this._getLeague() !== "mlb") return;
+    const leagues = Array.isArray(this.leagues) ? this.leagues : this._getLeagues();
+    if (!leagues.includes("mlb")) return;
 
     try {
       const season = new Date().getFullYear();
@@ -87,7 +110,7 @@ module.exports = NodeHelper.create({
       const games = (json.dates && json.dates[0] && json.dates[0].games) || [];
 
       console.log(`⚾️ Sending ${games.length} MLB games to front-end.`);
-      this.sendSocketNotification("GAMES", games);
+      this.sendSocketNotification("GAMES", { league: "mlb", games });
     } catch (e) {
       console.error("🚨 MLB fetchGames failed:", e);
     }
@@ -102,7 +125,7 @@ module.exports = NodeHelper.create({
       const games = (json.dates && json.dates[0] && json.dates[0].games) || [];
 
       console.log(`🏒 Sending ${games.length} NHL games to front-end.`);
-      this.sendSocketNotification("GAMES", games);
+      this.sendSocketNotification("GAMES", { league: "nhl", games });
     } catch (e) {
       console.error("🚨 NHL fetchGames failed:", e);
     }
@@ -117,15 +140,44 @@ module.exports = NodeHelper.create({
       const games = json.events || [];
 
       console.log(`🏈 Sending ${games.length} NFL games to front-end.`);
-      this.sendSocketNotification("GAMES", games);
+      this.sendSocketNotification("GAMES", { league: "nfl", games });
     } catch (e) {
       console.error("🚨 NFL fetchGames failed:", e);
     }
   },
 
+  _sanitizeLeague(value) {
+    if (typeof value !== "string") return null;
+    const lower = value.trim().toLowerCase();
+    return SUPPORTED_LEAGUES.includes(lower) ? lower : null;
+  },
+
+  _getLeagues() {
+    const leagues = [];
+    if (this.config && Array.isArray(this.config.leagues)) {
+      for (const entry of this.config.leagues) {
+        const cleaned = this._sanitizeLeague(entry);
+        if (cleaned && !leagues.includes(cleaned)) leagues.push(cleaned);
+      }
+    } else if (this.config && typeof this.config.leagues === "string" && this.config.leagues.trim() !== "") {
+      const single = this._sanitizeLeague(this.config.leagues);
+      if (single) leagues.push(single);
+    }
+
+    if (!leagues.length) {
+      const fallback = this._sanitizeLeague(this.config && this.config.league);
+      leagues.push(fallback || "mlb");
+    }
+
+    return leagues;
+  },
+
   _getLeague() {
-    const league = this.config && this.config.league ? this.config.league : "mlb";
-    return String(league).trim().toLowerCase();
+    if (Array.isArray(this.leagues) && this.leagues.length) {
+      return this.leagues[0];
+    }
+    const fromConfig = this._getLeagues();
+    return fromConfig[0] || "mlb";
   },
 
   _getTargetDate() {


### PR DESCRIPTION
## Summary
- add a `leagues` array option so one module instance can rotate through multiple sports before the MLB standings
- track games per league on the front-end and adjust pagination, headers, and placeholders for the active sport
- fetch games per league in the node helper and document the new configuration and behaviour in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9568135848322816749a4c32dc3ba