### PR TITLE
Add league-specific highlighted team preferences

### DIFF
--- a/MMM-ScoresAndStandings.js
+++ b/MMM-ScoresAndStandings.js
@@ -51,7 +51,9 @@
       rotateIntervalCentral:          12 * 1000,
       rotateIntervalWest:              7 * 1000,
       timeZone:               "America/Chicago",
-      highlightedTeams:                 [],
+      highlightedTeams_mlb:             [],
+      highlightedTeams_nhl:             [],
+      highlightedTeams_nfl:             [],
       showTitle:                        true,
       useTimesSquareFont:               true,
 
@@ -126,6 +128,13 @@
     _getLeague: function () {
       var league = this.config && this.config.league ? this.config.league : "mlb";
       return String(league).trim().toLowerCase();
+    },
+
+    _getHighlightedTeamsConfig: function () {
+      var league = this._getLeague();
+      if (league === "nhl") return this.config.highlightedTeams_nhl;
+      if (league === "nfl") return this.config.highlightedTeams_nfl;
+      return this.config.highlightedTeams_mlb;
     },
 
     _injectHeaderWidthStyle: function () {
@@ -1175,9 +1184,25 @@
     },
 
     _isHighlighted: function (abbr) {
-      var h = this.config.highlightedTeams;
-      if (Array.isArray(h)) return h.indexOf(abbr) !== -1;
-      if (typeof h === "string") return h.toUpperCase() === String(abbr).toUpperCase();
+      var h = this._getHighlightedTeamsConfig();
+
+      // Backwards compatibility for legacy `highlightedTeams`
+      if ((h == null || (Array.isArray(h) && h.length === 0)) && this.config.highlightedTeams != null) {
+        h = this.config.highlightedTeams;
+      }
+
+      if (Array.isArray(h)) {
+        var upper = String(abbr || "").toUpperCase();
+        for (var i = 0; i < h.length; i++) {
+          if (String(h[i] || "").toUpperCase() === upper) return true;
+        }
+        return false;
+      }
+
+      if (typeof h === "string") {
+        return String(h).toUpperCase() === String(abbr || "").toUpperCase();
+      }
+
       return false;
     },
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ Add to your `config/config.js`:
 
     // Behavior
     timeZone: "America/Chicago",
-    highlightedTeams: ["CUBS"], // string or array of 3–5 letter abbrs
+    highlightedTeams_mlb: ["CUBS"], // string or array of 3–5 letter abbrs (per league)
+    highlightedTeams_nhl: [],
+    highlightedTeams_nfl: [],
     showTitle: true,
     useTimesSquareFont: true,   // set false to use the MagicMirror default font
 
@@ -118,7 +120,9 @@ Add to your `config/config.js`:
 **Notes**
 - **League**: set `league` to `"nhl"` or `"nfl"` for hockey or football scoreboards (standings are MLB-only).
 - **Header width** matches `maxWidth` and stays in the default MM font (Roboto Condensed).
-- **Highlighted teams** accept a single string `"CUBS"` or an array like `["CUBS","NYY"]`.
+- **Highlighted teams** accept a single string `"CUBS"` or an array like `["CUBS","NYY"]` for
+  the league-specific settings `highlightedTeams_mlb`, `highlightedTeams_nhl`, and
+  `highlightedTeams_nfl`.
 - **layoutScale** is the quickest way to fix oversize boxes—values below `1` compact the layout.
 - When both standings views are enabled the rotation order is *Scoreboard → (NL/AL East) →
   (NL/AL Central) → (NL/AL West) → NL WC → AL WC*. Pages you disable are skipped entirely.


### PR DESCRIPTION
## Summary
- add league-specific highlighted team preference defaults for MLB, NHL, and NFL
- update highlight logic to respect the league-specific lists while preserving legacy support
- document the new configuration options in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d96c31931c8322905e6fd05d31a916