### PR TITLE
Add ALL league rotation support

### DIFF
--- a/MMM-ScoresAndStandings.css
+++ b/MMM-ScoresAndStandings.css
@@ -9,15 +9,15 @@
 
   /* ===== Scoreboard ===== */
   --scoreboard-card-width-base:      320px;
-  --scoreboard-pad-block-base:        10px;
+  --scoreboard-pad-block-base:         9px;
   --scoreboard-pad-inline-base:       14px;
   --scoreboard-gap-base:               8px;
-  --scoreboard-status-font-base:      calc(18px + 2pt);
+  --scoreboard-status-font-base:      18px;
   --scoreboard-label-font-base:       12px;
   --scoreboard-team-font-base:        28px;
-  --scoreboard-value-font-base:       calc(32px + 4pt);
+  --scoreboard-value-font-base:       32px;
   --scoreboard-metric-width-base:     56px;
-  --scoreboard-placeholder-height-base: 184px;
+  --scoreboard-placeholder-height-base: calc(184px * 0.9);
 
   --scoreboard-card-width:    calc(var(--scoreboard-card-width-base) * var(--box-scale));
   --scoreboard-pad-block:     calc(var(--scoreboard-pad-block-base) * var(--box-scale));
@@ -205,6 +205,13 @@
   color: var(--scoreboard-value-color);
   line-height: 1;
   font-weight: 700;
+}
+
+.font-times-square .scoreboard-card .scoreboard-status,
+.font-times-square .scoreboard-card .scoreboard-label,
+.font-times-square .scoreboard-card .scoreboard-team-abbr,
+.font-times-square .scoreboard-card .scoreboard-value {
+  font-weight: 400;
 }
 
 .scoreboard-card.is-live {

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Add to your `config/config.js`:
     // Refresh
     updateIntervalScores: 60 * 1000,
 
-    league: "mlb",             // "mlb", "nhl", or "nfl"
+    league: "mlb",             // "mlb", "nhl", "nfl", array of leagues, or "all"
 
     // Scoreboard layout
     scoreboardColumns: 2,     // number of columns of game boxes per page
@@ -86,7 +86,7 @@ Add to your `config/config.js`:
 ```
 
 **Notes**
-- **League**: set `league` to `"nhl"` or `"nfl"` for hockey or football scoreboards.
+- **League**: set `league` to `"nhl"` or `"nfl"` for hockey or football scoreboards. Use `"all"` (or provide an array via `league` or `leagues`) to rotate through every supported league automatically.
 - **Header width** matches `maxWidth` and stays in the default MM font (Roboto Condensed).
 - **Highlighted teams** accept a single string `"CUBS"` or an array like `["CUBS","NYY"]` for the league-specific settings `highlightedTeams_mlb`, `highlightedTeams_nhl`, and `highlightedTeams_nfl`.
 - **layoutScale** is the quickest way to fix oversize boxes—values below `1` compact the layout.


### PR DESCRIPTION
## Summary
- shrink scoreboard padding and placeholder height while reducing status/value font bases for a shorter card
- stop faux-bold rendering of the Times Square font by overriding font weights when that face is used
- harden NHL and NFL card builders to coerce score metrics from multiple API fields and show numbers whenever data is present
- allow the module to request every supported league via an `all` selection, rotating between per-league scoreboards on the front-end and tagging helper payloads with their source league

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9a4e66bac8322b922e77e635dae04