### PR TITLE
Keep NFL team totals inline with team info

### DIFF
--- a/MMM-ScoresAndStandings.css
+++ b/MMM-ScoresAndStandings.css
@@ -183,6 +183,14 @@
   gap: calc(var(--scoreboard-team-font) * 0.25);
 }
 
+.scoreboard-card .scoreboard-team-total {
+  font-size: var(--scoreboard-value-font);
+  font-weight: 700;
+  color: var(--scoreboard-value-color);
+  margin-left: auto;
+  line-height: 1;
+}
+
 .scoreboard-card .scoreboard-team-logo {
   height: calc(var(--scoreboard-team-font) * 0.8);
   max-height: calc(var(--scoreboard-team-font) * 0.9);
@@ -205,6 +213,42 @@
   color: var(--scoreboard-value-color);
   line-height: 1;
   font-weight: 700;
+}
+
+.scoreboard-card.league-nfl .scoreboard-header,
+.scoreboard-card.league-nfl .scoreboard-row {
+  justify-items: center;
+}
+
+.scoreboard-card.league-nfl .scoreboard-status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: calc(var(--scoreboard-gap) * 0.5);
+  width: 100%;
+}
+
+.scoreboard-card.league-nfl .scoreboard-team-total-label {
+  margin-left: auto;
+  font-size: var(--scoreboard-label-font);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--scoreboard-muted);
+  font-weight: 600;
+}
+
+.scoreboard-card.league-nfl .scoreboard-team {
+  width: 100%;
+  flex-wrap: nowrap;
+}
+
+.scoreboard-card.league-nfl .scoreboard-header .scoreboard-status,
+.scoreboard-card.league-nfl .scoreboard-row .scoreboard-team {
+  justify-self: start;
+}
+
+.scoreboard-card.league-nfl .scoreboard-row .scoreboard-value {
+  font-size: calc(var(--scoreboard-value-font) * 0.7);
 }
 
 .font-times-square .scoreboard-card .scoreboard-status,

--- a/MMM-ScoresAndStandings.js
+++ b/MMM-ScoresAndStandings.js
@@ -471,6 +471,12 @@
       var statusEl = document.createElement("div");
       statusEl.className = "scoreboard-status" + (live ? " live" : "");
       statusEl.textContent = (config && config.statusText) ? config.statusText : "";
+      if (config && config.teamTotalLabel) {
+        var totalLabelEl = document.createElement("span");
+        totalLabelEl.className = "scoreboard-team-total-label";
+        totalLabelEl.textContent = config.teamTotalLabel;
+        statusEl.appendChild(totalLabelEl);
+      }
       header.appendChild(statusEl);
 
       for (var li = 0; li < metricLabels.length; li++) {
@@ -520,6 +526,22 @@
         team.appendChild(abbrEl);
 
         if (rowData.highlight) team.classList.add("team-highlight");
+
+        if (Object.prototype.hasOwnProperty.call(rowData, "total") || Object.prototype.hasOwnProperty.call(rowData, "totalPlaceholder")) {
+          var totalEl = document.createElement("span");
+          totalEl.className = "scoreboard-team-total";
+          var totalPlaceholder = (rowData.totalPlaceholder != null) ? rowData.totalPlaceholder : "—";
+          if (showVals) {
+            if (rowData.total == null || rowData.total === "") {
+              totalEl.textContent = "";
+            } else {
+              totalEl.textContent = String(rowData.total);
+            }
+          } else {
+            totalEl.textContent = totalPlaceholder;
+          }
+          team.appendChild(totalEl);
+        }
         row.appendChild(team);
 
         var metrics = Array.isArray(rowData.metrics) ? rowData.metrics : [];
@@ -837,7 +859,24 @@
         }
 
         var metrics = quarters.slice();
-        metrics.push(scoreNum);
+
+        var totalScore = scoreNum;
+        if (totalScore == null) {
+          var runningTotal = 0;
+          var haveQuarterScore = false;
+          for (var qIdx = 0; qIdx < quarters.length; qIdx++) {
+            var quarterVal = quarters[qIdx];
+            if (quarterVal == null || quarterVal === "") continue;
+            var numericQuarter = Number(quarterVal);
+            if (!isNaN(numericQuarter)) {
+              runningTotal += numericQuarter;
+              haveQuarterScore = true;
+            }
+          }
+          if (haveQuarterScore) {
+            totalScore = runningTotal;
+          }
+        }
 
         var otherScore = null;
         if (idx === 0 && home) {
@@ -857,7 +896,9 @@
           logoAbbr: abbr,
           highlight: highlight,
           isLoser: isLoser,
-          metrics: metrics
+          metrics: metrics,
+          total: totalScore,
+          totalPlaceholder: isPreview ? "" : "—"
         });
       }
 
@@ -868,9 +909,10 @@
         live: isLive,
         showValues: showVals,
         statusText: statusText,
-        metricLabels: ["Q1", "Q2", "Q3", "Q4", "TOT"],
+        metricLabels: ["Q1", "Q2", "Q3", "Q4"],
         rows: rows,
-        cardClasses: cardClasses
+        cardClasses: cardClasses,
+        teamTotalLabel: "TOT"
       });
     },
 


### PR DESCRIPTION
## Summary
- move the NFL total score into the team row so the logo, abbreviation, and score share one line
- add a header label for the inline total while leaving quarter columns under their Q1-Q4 headings
- style the inline total and header label while keeping reduced quarter typography for NFL games

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d9aeb50cc883229e956183cb778d04