### PR TITLE
Simplify NFL scoreboard totals

### DIFF
--- a/MMM-ScoresAndStandings.css
+++ b/MMM-ScoresAndStandings.css
@@ -217,24 +217,15 @@
 
 .scoreboard-card.league-nfl .scoreboard-header,
 .scoreboard-card.league-nfl .scoreboard-row {
-  justify-items: center;
+  justify-items: stretch;
 }
 
 .scoreboard-card.league-nfl .scoreboard-status {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: calc(var(--scoreboard-gap) * 0.5);
   width: 100%;
-}
-
-.scoreboard-card.league-nfl .scoreboard-team-total-label {
-  margin-left: auto;
-  font-size: var(--scoreboard-label-font);
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: var(--scoreboard-muted);
-  font-weight: 600;
 }
 
 .scoreboard-card.league-nfl .scoreboard-team {
@@ -245,10 +236,6 @@
 .scoreboard-card.league-nfl .scoreboard-header .scoreboard-status,
 .scoreboard-card.league-nfl .scoreboard-row .scoreboard-team {
   justify-self: start;
-}
-
-.scoreboard-card.league-nfl .scoreboard-row .scoreboard-value {
-  font-size: calc(var(--scoreboard-value-font) * 0.7);
 }
 
 .font-times-square .scoreboard-card .scoreboard-status,

--- a/MMM-ScoresAndStandings.js
+++ b/MMM-ScoresAndStandings.js
@@ -858,8 +858,6 @@
           }
         }
 
-        var metrics = quarters.slice();
-
         var totalScore = scoreNum;
         if (totalScore == null) {
           var runningTotal = 0;
@@ -896,7 +894,7 @@
           logoAbbr: abbr,
           highlight: highlight,
           isLoser: isLoser,
-          metrics: metrics,
+          metrics: [],
           total: totalScore,
           totalPlaceholder: isPreview ? "" : "—"
         });
@@ -909,10 +907,9 @@
         live: isLive,
         showValues: showVals,
         statusText: statusText,
-        metricLabels: ["Q1", "Q2", "Q3", "Q4"],
+        metricLabels: [],
         rows: rows,
-        cardClasses: cardClasses,
-        teamTotalLabel: "TOT"
+        cardClasses: cardClasses
       });
     },
 


### PR DESCRIPTION
## Summary
- remove quarter-by-quarter metrics from NFL scoreboard cards so only current totals are shown
- adjust the NFL scoreboard layout styles to align the slimmer presentation

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d9b281f18483228ca7e64cdf20b240