### PR TITLE
Halve NFL scoreboard card width

### DIFF
--- a/MMM-ScoresAndStandings.css
+++ b/MMM-ScoresAndStandings.css
@@ -8,7 +8,7 @@
   --box-scale: 1;
 
   /* ===== Scoreboard ===== */
-  --scoreboard-card-width-base:      320px;
+  --scoreboard-card-width-base:      160px;
   --scoreboard-pad-block-base:         9px;
   --scoreboard-pad-inline-base:       14px;
   --scoreboard-gap-base:               8px;


### PR DESCRIPTION
## Summary
- reduce the base width of NFL scoreboard cards to cut their rendered width in half

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9b3d6fa9c83228f8f03b7daefbb06