### PR TITLE
Adjust NFL scoreboard card width

### DIFF
--- a/MMM-ScoresAndStandings.css
+++ b/MMM-ScoresAndStandings.css
@@ -8,7 +8,8 @@
   --box-scale: 1;
 
   /* ===== Scoreboard ===== */
-  --scoreboard-card-width-base:      160px;
+  --scoreboard-card-width-base:      320px;
+  --scoreboard-card-width-base-nfl:  200px;
   --scoreboard-pad-block-base:         9px;
   --scoreboard-pad-inline-base:       14px;
   --scoreboard-gap-base:               8px;
@@ -87,6 +88,10 @@
   width: var(--scoreboard-card-width);
 }
 
+.games-matrix-cell.league-nfl {
+  --scoreboard-card-width-base: var(--scoreboard-card-width-base-nfl);
+}
+
 .games-matrix-cell.empty::before {
   content: "";
   display: inline-block;
@@ -125,6 +130,10 @@
   font-family: var(--scoreboard-font-family);
   color: var(--scoreboard-text);
   --metric-count: 3;
+}
+
+.scoreboard-card.league-nfl {
+  --scoreboard-card-width-base: var(--scoreboard-card-width-base-nfl);
 }
 
 .scoreboard-card .scoreboard-header,

--- a/MMM-ScoresAndStandings.js
+++ b/MMM-ScoresAndStandings.js
@@ -423,7 +423,18 @@
           var index = r * this._scoreboardColumns + c;
           var game = games[index];
           if (game) {
-            cell.appendChild(this.createGameBox(game));
+            var card = this.createGameBox(game);
+            if (card) {
+              cell.appendChild(card);
+
+              for (var cl = 0; cl < card.classList.length; cl++) {
+                var cls = card.classList[cl];
+                if (cls && cls.indexOf("league-") === 0) {
+                  cell.classList.add(cls);
+                  break;
+                }
+              }
+            }
           } else {
             cell.classList.add("empty");
           }


### PR DESCRIPTION
## Summary
- restore the default scoreboard card width variable to 320px
- introduce an NFL-specific card width variable and apply it to NFL scoreboards
- tag scoreboard cells with the league class so NFL sizing cascades correctly

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d9b58bfd6083228d459c310000f7de