### PR TITLE
Ensure NFL scoreboard uses dedicated width

### DIFF
--- a/MMM-ScoresAndStandings.css
+++ b/MMM-ScoresAndStandings.css
@@ -90,6 +90,7 @@
 
 .games-matrix-cell.league-nfl {
   --scoreboard-card-width-base: var(--scoreboard-card-width-base-nfl);
+  --scoreboard-card-width: calc(var(--scoreboard-card-width-base-nfl) * var(--box-scale));
 }
 
 .games-matrix-cell.empty::before {
@@ -134,6 +135,7 @@
 
 .scoreboard-card.league-nfl {
   --scoreboard-card-width-base: var(--scoreboard-card-width-base-nfl);
+  --scoreboard-card-width: calc(var(--scoreboard-card-width-base-nfl) * var(--box-scale));
 }
 
 .scoreboard-card .scoreboard-header,


### PR DESCRIPTION
## Summary
- ensure NFL scoreboard cells and cards recalculate their width using the NFL base variable so the narrower layout is applied

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9b80e63188322ba644a5524564820