### PR TITLE
Show full NFL week and persist final scores

### DIFF
--- a/MMM-ScoresAndStandings.js
+++ b/MMM-ScoresAndStandings.js
@@ -810,7 +810,7 @@
 
       var statusText = "";
       if (isPreview) {
-        statusText = this._formatStartTime(competition.date || game.date);
+        statusText = this._formatNflStartTime(competition.date || game.date);
       } else if (isFinal) {
         statusText = detailed || "Final";
       } else if (isLive) {
@@ -937,6 +937,26 @@
         });
       } catch (e) {
         return "";
+      }
+    },
+
+    _formatNflStartTime: function (isoDate) {
+      var timeText = this._formatStartTime(isoDate);
+      if (!isoDate) return timeText;
+      try {
+        var date = new Date(isoDate);
+        if (isNaN(date.getTime())) return timeText;
+        var tz = this.config.timeZone || "America/Chicago";
+        var weekday = date.toLocaleDateString("en-US", {
+          timeZone: tz,
+          weekday: "short"
+        });
+        if (!weekday) return timeText;
+        if (/^sun/i.test(weekday)) return timeText;
+        if (!timeText) return weekday;
+        return weekday + " " + timeText;
+      } catch (e) {
+        return timeText;
       }
     },
 


### PR DESCRIPTION
## Summary
- aggregate NFL scoreboard data for the entire Thursday-to-Monday week and keep results through Wednesday morning
- sort and de-duplicate the combined NFL events before delivering them to the client
- display the weekday prefix on non-Sunday NFL kickoff times

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d9b8f7392c83229a72d4076a257a5f