### PR TITLE
Adjust NFL scoreboard to four columns

### DIFF
--- a/MMM-ScoresAndStandings.js
+++ b/MMM-ScoresAndStandings.js
@@ -19,6 +19,7 @@
 
   // Scoreboard layout defaults (can be overridden via config)
   var DEFAULT_SCOREBOARD_COLUMNS    = 2;
+  var DEFAULT_SCOREBOARD_COLUMNS_NFL = 4;
   var DEFAULT_GAMES_PER_COLUMN      = 2;
 
   var SUPPORTED_LEAGUES = ["mlb", "nhl", "nfl"];
@@ -26,7 +27,7 @@
   Module.register("MMM-ScoresAndStandings", {
     defaults: {
       updateIntervalScores:            60 * 1000,
-      scoreboardColumns:               DEFAULT_SCOREBOARD_COLUMNS,
+      scoreboardColumns:               null,
       gamesPerColumn:                  DEFAULT_GAMES_PER_COLUMN,
       gamesPerPage:                      null,
       league:                        "mlb",
@@ -72,7 +73,7 @@
       }
       this._activeLeagueIndex = 0;
 
-      this._scoreboardColumns = DEFAULT_SCOREBOARD_COLUMNS;
+      this._scoreboardColumns = this._defaultColumnsForLeague();
       this._scoreboardRows    = DEFAULT_GAMES_PER_COLUMN;
       this._gamesPerPage      = this._scoreboardColumns * this._scoreboardRows;
       this._layoutScale       = 1;
@@ -217,8 +218,14 @@
       return finite && num > 0 ? num : fallback;
     },
 
+    _defaultColumnsForLeague: function () {
+      var league = this._getLeague();
+      if (league === "nfl") return DEFAULT_SCOREBOARD_COLUMNS_NFL;
+      return DEFAULT_SCOREBOARD_COLUMNS;
+    },
+
     _syncScoreboardLayout: function () {
-      var columns   = this._asPositiveInt(this.config.scoreboardColumns, DEFAULT_SCOREBOARD_COLUMNS);
+      var columns   = this._asPositiveInt(this.config.scoreboardColumns, this._defaultColumnsForLeague());
       var perColumn = this._asPositiveInt(this.config.gamesPerColumn, DEFAULT_GAMES_PER_COLUMN);
 
       var gamesPerPage = columns * perColumn;

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Add to your `config/config.js`:
     league: "mlb",             // "mlb", "nhl", "nfl", array of leagues, or "all"
 
     // Scoreboard layout
-    scoreboardColumns: 2,     // number of columns of game boxes per page
+    scoreboardColumns: null,  // columns per page (auto: 2 for MLB/NHL, 4 for NFL)
     gamesPerColumn: 2,        // games stacked in each column
     // (optional) gamesPerPage: 8, // override derived columns × gamesPerColumn
     layoutScale: 0.9,          // shrink (<1) or grow (>1) everything at once (clamped 0.6 – 1.4)
@@ -90,7 +90,7 @@ Add to your `config/config.js`:
 - **Header width** matches `maxWidth` and stays in the default MM font (Roboto Condensed).
 - **Highlighted teams** accept a single string `"CUBS"` or an array like `["CUBS","NYY"]` for the league-specific settings `highlightedTeams_mlb`, `highlightedTeams_nhl`, and `highlightedTeams_nfl`.
 - **layoutScale** is the quickest way to fix oversize boxes—values below `1` compact the layout.
-- The default scoreboard layout shows **two columns and up to four games** at a time. Adjust `scoreboardColumns`, `gamesPerColumn`, or `gamesPerPage` to taste.
+- The default scoreboard layout shows **two columns and up to four games** for MLB/NHL, and **four columns** for NFL. Adjust `scoreboardColumns`, `gamesPerColumn`, or `gamesPerPage` to taste.
 
 ---
 


### PR DESCRIPTION
## Summary
- default the NFL scoreboard layout to four columns while leaving MLB/NHL at two by adding league-aware column selection
- update the README configuration section to document the automatic column defaults

## Testing
- not run (module has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d9bac44d9883229e894db56add835e