### PR TITLE
Fix NFL scoreboard grid defaults

### DIFF
--- a/MMM-ScoresAndStandings.js
+++ b/MMM-ScoresAndStandings.js
@@ -29,7 +29,7 @@
     defaults: {
       updateIntervalScores:            60 * 1000,
       scoreboardColumns:               null,
-      gamesPerColumn:                  DEFAULT_GAMES_PER_COLUMN,
+      gamesPerColumn:                  null,
       gamesPerPage:                      null,
       league:                        "mlb",
       layoutScale:                     1.0,


### PR DESCRIPTION
## Summary
- allow the scoreboard to fall back to the league-specific row count when the configuration does not override it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da9d0ec61c8322a1d66e3ceec1a848