### PR TITLE
Fix NHL loading fallback and adjust NFL scoreboard width

### DIFF
--- a/MMM-ScoresAndStandings.css
+++ b/MMM-ScoresAndStandings.css
@@ -9,7 +9,7 @@
 
   /* ===== Scoreboard ===== */
   --scoreboard-card-width-base:      320px;
-  --scoreboard-card-width-base-nfl:  200px;
+  --scoreboard-card-width-base-nfl:  184px;
   --scoreboard-pad-block-base:         9px;
   --scoreboard-pad-inline-base:       14px;
   --scoreboard-gap-base:               8px;


### PR DESCRIPTION
## Summary
- ensure the NHL fetch pipeline always notifies the front-end, even when all endpoints fail
- fall back to an empty schedule notification when data is unavailable to avoid endless loading
- shrink the NFL card width so that all four columns remain visible within the module width cap

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68daf59f5e2483228576b0c5660895fc