### PR TITLE
Ensure NHL SOG persist and adjust scoreboard styling

### DIFF
--- a/MMM-ScoresAndStandings.css
+++ b/MMM-ScoresAndStandings.css
@@ -204,6 +204,14 @@
   line-height: 1;
 }
 
+.scoreboard-card.league-nfl .scoreboard-team-total {
+  color: var(--scoreboard-text);
+}
+
+.scoreboard-card.league-nfl .scoreboard-team-total.live {
+  color: var(--scoreboard-value-color);
+}
+
 .scoreboard-card .scoreboard-team-logo {
   height: calc(var(--scoreboard-team-font) * 0.88);
   max-height: calc(var(--scoreboard-team-font) * 0.99);
@@ -239,6 +247,14 @@
 
 .scoreboard-card .scoreboard-value.live {
   color: var(--scoreboard-value-color);
+}
+
+.scoreboard-card.league-nhl .scoreboard-label.shots-on-goal-label {
+  font-size: max(0px, calc(var(--scoreboard-label-font) - 5pt));
+}
+
+.scoreboard-card.league-nhl .scoreboard-value.shots-on-goal-value {
+  font-size: max(0px, calc(var(--scoreboard-value-font) - 5pt));
 }
 
 .scoreboard-card.league-nfl .scoreboard-header,


### PR DESCRIPTION
## Summary
- retain NHL shots on goal values after games end by expanding data normalization and client fallbacks
- support per-metric styling so SOG labels/values can be reduced in size on the NHL scoreboard
- only highlight NFL scoreboard totals in yellow while games are live

## Testing
- not run (MagicMirror module)

------
https://chatgpt.com/codex/tasks/task_e_68db48205fa0832299aa217a9cd6ca0e