### PR TITLE
Fix NFL scoreboard alignment with CSS grid layout

### DIFF
--- a/MMM-ScoresAndStandings.css
+++ b/MMM-ScoresAndStandings.css
@@ -75,30 +75,34 @@
 --------------------------------------------------*/
 
 .games-matrix {
-  border-collapse: separate;
-  border-spacing: var(--matrix-gap) var(--matrix-gap);
+  display: grid;
+  grid-template-columns: repeat(var(--games-matrix-columns, 1), minmax(0, var(--games-matrix-col-width, var(--scoreboard-card-width))));
+  gap: var(--matrix-gap);
   margin: 0;
-  table-layout: auto;
+  padding: 0;
   width: auto;
+  justify-content: center;
+  align-items: start;
+}
+
+.games-matrix.league-nfl,
+.games-matrix.league-nba {
+  --scoreboard-card-width-base: var(--scoreboard-card-width-base-nfl);
+  --scoreboard-card-width: calc(var(--scoreboard-card-width-base-nfl) * var(--box-scale));
+  --games-matrix-col-width: calc(var(--scoreboard-card-width-base-nfl) * var(--box-scale));
 }
 
 .games-matrix-cell {
-  vertical-align: top;
-  padding: 0;
+  width: var(--games-matrix-col-width, var(--scoreboard-card-width));
+  display: flex;
+  align-items: stretch;
   text-align: left;
-  width: var(--scoreboard-card-width);
-}
-
-.games-matrix-cell.league-nfl,
-.games-matrix-cell.league-nba {
-  --scoreboard-card-width-base: var(--scoreboard-card-width-base-nfl);
-  --scoreboard-card-width: calc(var(--scoreboard-card-width-base-nfl) * var(--box-scale));
 }
 
 .games-matrix-cell.empty::before {
   content: "";
-  display: inline-block;
-  width: var(--scoreboard-card-width);
+  display: block;
+  width: 100%;
   height: var(--scoreboard-placeholder-height);
   border-radius: var(--scoreboard-card-radius);
   background: rgba(0, 0, 0, 0.55);
@@ -106,6 +110,7 @@
 }
 
 .games-matrix-cell > .scoreboard-card {
+  width: 100%;
   margin: 0;
 }
 

--- a/MMM-ScoresAndStandings.js
+++ b/MMM-ScoresAndStandings.js
@@ -634,20 +634,20 @@
       var start = this.currentScreen * this._gamesPerPage;
       var games = this.games.slice(start, start + this._gamesPerPage);
 
-      var matrix = document.createElement("table");
+      var matrix = document.createElement("div");
       matrix.className = "games-matrix";
 
-      var tbody = document.createElement("tbody");
+      var activeLeague = this._getLeague();
+      if (activeLeague) matrix.classList.add("league-" + activeLeague);
+
+      matrix.style.setProperty("--games-matrix-columns", this._scoreboardColumns);
 
       for (var r = 0; r < this._scoreboardRows; r++) {
-        var row = document.createElement("tr");
-
         for (var c = 0; c < this._scoreboardColumns; c++) {
-          var cell = document.createElement("td");
-          cell.className = "games-matrix-cell";
-          cell.style.setProperty("--games-matrix-col-width", (100 / this._scoreboardColumns) + "%");
-
           var index = r * this._scoreboardColumns + c;
+          var cell = document.createElement("div");
+          cell.className = "games-matrix-cell";
+
           var game = games[index];
           if (game) {
             var card = this.createGameBox(game);
@@ -666,13 +666,10 @@
             cell.classList.add("empty");
           }
 
-          row.appendChild(cell);
+          matrix.appendChild(cell);
         }
-
-        tbody.appendChild(row);
       }
 
-      matrix.appendChild(tbody);
       return matrix;
     },
 


### PR DESCRIPTION
## Summary
- render the scoreboard matrix with div-based markup that carries the active league class
- restyle the scoreboard grid to use CSS Grid so NFL cards align evenly and placeholders size correctly

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68ded2c9cb208322972644a6932f0dce