### PR TITLE
Align pro league scoreboard layout defaults

### DIFF
--- a/MMM-ScoresAndStandings.css
+++ b/MMM-ScoresAndStandings.css
@@ -8,8 +8,8 @@
   --box-scale: 1;
 
   /* ===== Scoreboard ===== */
-  --scoreboard-card-width-base:      320px;
-  --scoreboard-card-width-base-nfl:  170px;
+  --scoreboard-card-width-base:            320px;
+  --scoreboard-card-width-base-compact:    170px;
   --scoreboard-pad-block-base:         9px;
   --scoreboard-pad-inline-base:       14px;
   --scoreboard-gap-base:               8px;
@@ -86,10 +86,10 @@
 }
 
 .games-matrix.league-nfl,
+.games-matrix.league-nhl,
 .games-matrix.league-nba {
-  --scoreboard-card-width-base: var(--scoreboard-card-width-base-nfl);
-  --scoreboard-card-width: calc(var(--scoreboard-card-width-base-nfl) * var(--box-scale));
-  --games-matrix-col-width: calc(var(--scoreboard-card-width-base-nfl) * var(--box-scale));
+  --scoreboard-card-width-base: var(--scoreboard-card-width-base-compact);
+  --games-matrix-col-width: calc(var(--scoreboard-card-width-base) * var(--box-scale));
 }
 
 .games-matrix-cell {
@@ -141,10 +141,9 @@
 }
 
 .scoreboard-card.league-nfl,
-.scoreboard-card.league-nba,
-.scoreboard-card.league-nhl {
-  --scoreboard-card-width-base: var(--scoreboard-card-width-base-nfl);
-  --scoreboard-card-width: calc(var(--scoreboard-card-width-base-nfl) * var(--box-scale));
+.scoreboard-card.league-nhl,
+.scoreboard-card.league-nba {
+  --scoreboard-card-width-base: var(--scoreboard-card-width-base-compact);
 }
 
 .scoreboard-card .scoreboard-header,

--- a/MMM-ScoresAndStandings.js
+++ b/MMM-ScoresAndStandings.js
@@ -19,11 +19,11 @@
 
   // Scoreboard layout defaults (can be overridden via config)
   var DEFAULT_SCOREBOARD_COLUMNS        = 2;
-  var DEFAULT_SCOREBOARD_COLUMNS_NFL    = 4;
-  var DEFAULT_SCOREBOARD_COLUMNS_NBA    = 4;
+  var DEFAULT_SCOREBOARD_COLUMNS_PRO    = 4;
   var DEFAULT_GAMES_PER_COLUMN          = 2;
-  var DEFAULT_GAMES_PER_COLUMN_NFL      = 4;
-  var DEFAULT_GAMES_PER_COLUMN_NBA      = 4;
+  var DEFAULT_GAMES_PER_COLUMN_PRO      = 4;
+
+  var EXTENDED_LAYOUT_LEAGUES = { nfl: true, nhl: true, nba: true };
 
   var SUPPORTED_LEAGUES = ["mlb", "nhl", "nfl", "nba"];
 
@@ -226,15 +226,13 @@
 
     _defaultColumnsForLeague: function () {
       var league = this._getLeague();
-      if (league === "nfl") return DEFAULT_SCOREBOARD_COLUMNS_NFL;
-      if (league === "nba") return DEFAULT_SCOREBOARD_COLUMNS_NBA;
+      if (EXTENDED_LAYOUT_LEAGUES[league]) return DEFAULT_SCOREBOARD_COLUMNS_PRO;
       return DEFAULT_SCOREBOARD_COLUMNS;
     },
 
     _defaultRowsForLeague: function () {
       var league = this._getLeague();
-      if (league === "nfl") return DEFAULT_GAMES_PER_COLUMN_NFL;
-      if (league === "nba") return DEFAULT_GAMES_PER_COLUMN_NBA;
+      if (EXTENDED_LAYOUT_LEAGUES[league]) return DEFAULT_GAMES_PER_COLUMN_PRO;
       return DEFAULT_GAMES_PER_COLUMN;
     },
 
@@ -252,7 +250,9 @@
         defaultRows
       );
 
-      if (league === "nfl" || league === "nba") {
+      var requiresExtendedLayout = !!EXTENDED_LAYOUT_LEAGUES[league];
+
+      if (requiresExtendedLayout) {
         if (columns < defaultCols) columns = defaultCols;
         if (perColumn < defaultRows) perColumn = defaultRows;
       }
@@ -264,7 +264,7 @@
         var override = this._asPositiveInt(gamesPerPageConfig, gamesPerPage);
         var computedRows = Math.max(1, Math.ceil(override / columns));
 
-        if (league === "nfl" || league === "nba") {
+        if (requiresExtendedLayout) {
           if (computedRows < defaultRows) computedRows = defaultRows;
           perColumn = computedRows;
           gamesPerPage = columns * perColumn;

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Add to your `config/config.js`:
     league: "mlb",             // "mlb", "nhl", "nfl", "nba", array of leagues, or "all"
 
     // Scoreboard layout
-    scoreboardColumns: null,  // columns per page (auto: 2 for MLB/NHL, 4 for NFL/NBA)
-    gamesPerColumn: 2,        // games stacked in each column
+    scoreboardColumns: null,  // columns per page (auto: 2 for MLB, 4 for NHL/NFL/NBA)
+    gamesPerColumn: 2,        // games stacked in each column (auto expands to 4 for NHL/NFL/NBA)
     // (optional) gamesPerPage: 8, // override derived columns × gamesPerColumn
     layoutScale: 0.9,          // shrink (<1) or grow (>1) everything at once (clamped 0.6 – 1.4)
     rotateIntervalScores: 15 * 1000,
@@ -91,7 +91,7 @@ Add to your `config/config.js`:
 - **Header width** matches `maxWidth` and stays in the default MM font (Roboto Condensed).
 - **Highlighted teams** accept a single string `"CUBS"` or an array like `["CUBS","NYY"]` for the league-specific settings `highlightedTeams_mlb`, `highlightedTeams_nhl`, `highlightedTeams_nfl`, and `highlightedTeams_nba`.
 - **layoutScale** is the quickest way to fix oversize boxes—values below `1` compact the layout.
-- The default scoreboard layout shows **two columns and up to four games** for MLB/NHL, and **four columns** for NFL/NBA. Adjust `scoreboardColumns`, `gamesPerColumn`, or `gamesPerPage` to taste.
+- The default scoreboard layout shows **two columns and up to four games** for MLB, and **four columns with four rows (16 games)** for NHL/NFL/NBA. Adjust `scoreboardColumns`, `gamesPerColumn`, or `gamesPerPage` to taste.
 
 ---
 


### PR DESCRIPTION
## Summary
- treat NHL with the same 4x4 scoreboard defaults as NFL and NBA
- reuse a shared compact card width variable so all pro league cards render at the same size
- document the updated layout expectations in the README

## Testing
- not run (module changes only)


------
https://chatgpt.com/codex/tasks/task_e_68ded78d31a08322b3b95c24e7acbcba