### PR TITLE
Clamp MLB scoreboard pages to eight games

### DIFF
--- a/MMM-ScoresAndStandings.css
+++ b/MMM-ScoresAndStandings.css
@@ -68,17 +68,30 @@
   font-weight: bold;
   margin: 0;
 }
-.scores-screen .module-header + hr { border: none; border-bottom: 1px solid #999; margin: 4px 0 8px; }
+.MMM-ScoresAndStandings .module-header + hr {
+  border: none;
+  border-bottom: 1px solid #999;
+  width: min(100%, var(--scoreboard-content-width, 100%));
+  margin: 4px auto 8px;
+}
 
 /*--------------------------------------------------
   Scoreboard Grid
 --------------------------------------------------*/
 
+.games-layout {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: calc(var(--matrix-gap) * 1.25);
+}
+
 .games-matrix {
   display: grid;
   grid-template-columns: repeat(var(--games-matrix-columns, 1), minmax(0, var(--games-matrix-col-width, var(--scoreboard-card-width))));
   gap: var(--matrix-gap);
-  margin: 0;
+  margin: 0 auto;
   padding: 0;
   width: auto;
   justify-content: center;
@@ -112,6 +125,72 @@
 .games-matrix-cell > .scoreboard-card {
   width: 100%;
   margin: 0;
+}
+
+/*--------------------------------------------------
+  NFL Bye Section
+--------------------------------------------------*/
+.bye-week-section {
+  width: min(100%, var(--scoreboard-content-width, 100%));
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: calc(var(--matrix-gap) * 0.75);
+}
+
+.bye-week-title {
+  font-size: var(--scoreboard-label-font);
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--scoreboard-muted);
+  font-weight: 600;
+}
+
+.bye-week-list {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: calc(var(--matrix-gap) * 0.75);
+}
+
+.bye-week-team {
+  display: flex;
+  align-items: center;
+  gap: calc(var(--scoreboard-gap) * 0.75);
+  padding: calc(var(--scoreboard-pad-block) * 0.9) calc(var(--scoreboard-pad-inline) * 0.9);
+  border-radius: calc(var(--scoreboard-card-radius) * 0.6);
+  background: rgba(0, 0, 0, 0.45);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: inset 0 0 16px rgba(0, 0, 0, 0.35);
+  min-width: calc(var(--scoreboard-card-width) * 0.45);
+}
+
+.bye-week-team-logo {
+  height: calc(var(--scoreboard-team-font) * 0.85);
+  width: auto;
+  display: block;
+}
+
+.bye-week-team-text {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--scoreboard-gap) * 0.2);
+  line-height: 1.1;
+}
+
+.bye-week-team-abbr {
+  font-size: calc(var(--scoreboard-team-font) * 0.9);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
+.bye-week-team-name {
+  font-size: calc(var(--scoreboard-label-font) * 1.05);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--scoreboard-muted);
+  font-weight: 600;
 }
 
 /*--------------------------------------------------


### PR DESCRIPTION
## Summary
- add a league-aware maximum so the MLB scoreboard caps each page at eight games
- adjust the layout synchronization logic to honor the MLB limit while respecting configured column and row minimums

## Testing
- not run (MagicMirror environment)

------
https://chatgpt.com/codex/tasks/task_e_68dee99392748322a7bfcbe6e168c40c