### PR TITLE
Show NFL bye teams after last page

### DIFF
--- a/MMM-ScoresAndStandings.js
+++ b/MMM-ScoresAndStandings.js
@@ -877,8 +877,12 @@
       if (activeLeague === "nfl") {
         var extras = this.currentExtras;
         var byeTeams = extras && Array.isArray(extras.teamsOnBye) ? extras.teamsOnBye : [];
-        var byeSection = this._buildNflByeSection(byeTeams);
-        if (byeSection) container.appendChild(byeSection);
+        var totalPages = Math.max(1, this.totalGamePages || 1);
+        var onLastPage = this.currentScreen >= (totalPages - 1);
+        if (onLastPage) {
+          var byeSection = this._buildNflByeSection(byeTeams);
+          if (byeSection) container.appendChild(byeSection);
+        }
       }
 
       return container;


### PR DESCRIPTION
## Summary
- ensure the NFL bye section only renders after the final scoreboard page so it follows the last game listing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68def2578cf08322874f122ada302156