### PR TITLE
Adjust module header divider width

### DIFF
--- a/MMM-ScoresAndStandings.css
+++ b/MMM-ScoresAndStandings.css
@@ -71,7 +71,7 @@
 .MMM-ScoresAndStandings .module-header + hr {
   border: none;
   border-bottom: 1px solid #999;
-  width: min(100%, var(--scoreboard-content-width, 100%));
+  width: min(100%, var(--scoreboard-content-width, var(--scoreboard-card-width)));
   margin: 4px auto 8px;
 }
 


### PR DESCRIPTION
## Summary
- narrow the module header divider so it honors the scoreboard content width or single-card width fallback

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68def332ebbc8322b4e5e3d286453677