### PR TITLE
Set NHL SOG superscript color to white

### DIFF
--- a/MMM-ScoresAndStandings.css
+++ b/MMM-ScoresAndStandings.css
@@ -343,7 +343,7 @@
 }
 
 .scoreboard-card.league-nhl .scoreboard-value.shots-on-goal-value sup {
-  color: var(--scoreboard-muted);
+  color: var(--scoreboard-text);
 }
 
 .scoreboard-card.league-nfl .scoreboard-header,


### PR DESCRIPTION
## Summary
- update the NHL scoreboard superscript color for shots on goal to use the primary text color

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1b8df872883229ed0c5ded0227a97