### PR TITLE
Include WBC games in MLB scoreboard feed

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -62,6 +62,7 @@ const fetch = (typeof global.fetch === "function")
   : createHttpFetchFallback();
 
 const SUPPORTED_LEAGUES = ["mlb", "nhl", "nfl", "nba", "olympic_mhockey", "olympic_whockey"];
+const MLB_SCOREBOARD_SPORT_IDS = [1, 51]; // MLB + World Baseball Classic
 
 const DNS_LOOKUP = (dns && dns.promises && typeof dns.promises.lookup === "function")
   ? (host) => dns.promises.lookup(host)
@@ -133,13 +134,24 @@ module.exports = NodeHelper.create({
   async _fetchMlbGames() {
     try {
       const { dateIso } = this._getTargetDate();
-      const url  = `https://statsapi.mlb.com/api/v1/schedule/games?sportId=1&date=${dateIso}&hydrate=linescore`;
-      const res  = await fetch(url);
-      if (!res.ok) {
-        throw new Error(`HTTP ${res.status} ${res.statusText}`);
+      const gamesByPk = new Map();
+
+      for (const sportId of MLB_SCOREBOARD_SPORT_IDS) {
+        const games = await this._fetchMlbGamesBySport(dateIso, sportId);
+        for (let i = 0; i < games.length; i += 1) {
+          const game = games[i];
+          const gamePk = Number(game && game.gamePk);
+          if (Number.isFinite(gamePk)) {
+            gamesByPk.set(gamePk, game);
+          }
+        }
       }
-      const json = await res.json();
-      const games = (json.dates && json.dates[0] && json.dates[0].games) || [];
+
+      const games = Array.from(gamesByPk.values()).sort((a, b) => {
+        const aDate = Date.parse((a && a.gameDate) || "") || 0;
+        const bDate = Date.parse((b && b.gameDate) || "") || 0;
+        return aDate - bDate;
+      });
 
       console.log(`⚾️ Sending ${games.length} MLB games to front-end.`);
       this._notifyGames("mlb", games);
@@ -147,6 +159,28 @@ module.exports = NodeHelper.create({
       console.error("🚨 MLB fetchGames failed:", e);
       this._notifyGames("mlb", []);
     }
+  },
+
+  async _fetchMlbGamesBySport(dateIso, sportId) {
+    const url = `https://statsapi.mlb.com/api/v1/schedule/games?sportId=${sportId}&date=${dateIso}&hydrate=linescore`;
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status} ${res.statusText} (sportId=${sportId})`);
+    }
+
+    const json = await res.json();
+    const games = [];
+    const dates = Array.isArray(json && json.dates) ? json.dates : [];
+
+    for (let i = 0; i < dates.length; i += 1) {
+      const dateBucket = dates[i];
+      if (!dateBucket || !Array.isArray(dateBucket.games)) continue;
+      for (let j = 0; j < dateBucket.games.length; j += 1) {
+        games.push(dateBucket.games[j]);
+      }
+    }
+
+    return games;
   },
 
   async _fetchNhlGames() {


### PR DESCRIPTION
### Motivation
- Ensure World Baseball Classic (WBC) games are shown on the MLB scoreboard by consuming the WBC schedule feed in addition to the MLB feed.
- The MLB stats API exposes different `sportId` values for MLB and international events, so the scoreboard must query both to include all relevant games.

### Description
- Added `MLB_SCOREBOARD_SPORT_IDS = [1, 51]` to query both MLB and WBC schedules.
- Refactored `_fetchMlbGames` to iterate `MLB_SCOREBOARD_SPORT_IDS`, merge results, de-duplicate by `gamePk`, and sort games chronologically by `gameDate` before notifying the front end.
- Added helper `async _fetchMlbGamesBySport(dateIso, sportId)` to fetch and flatten `dates[].games` for a given sport id and surface sport-specific HTTP errors.
- All changes are contained in `node_helper.js` and preserve the existing `linescore` hydration request.

### Testing
- Ran `node --check node_helper.js` which passed without syntax errors.
- Ran `node --check MMM-Scores.js` which passed without syntax errors.
- Ran `npm run test:api` which failed due to networking/DNS restrictions in the environment (`ENETUNREACH` / `ENOTFOUND`), indicating test failures are environmental and not due to local code syntax or logic errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa39122e0083228047c718e8e22038)