### PR TITLE
Fix WBC team-to-flag mapping for MLB international entries

### DIFF
--- a/MMM-Scores.js
+++ b/MMM-Scores.js
@@ -63,6 +63,34 @@
     944: "Venezuela"
   };
 
+  var MLB_INTERNATIONAL_ABBREVIATIONS_BY_COUNTRY_NAME = {
+    "australia": "AUS",
+    "brazil": "BRA",
+    "canada": "CAN",
+    "chinese taipei": "TPE",
+    "colombia": "COL",
+    "cuba": "CUB",
+    "czech republic": "CZE",
+    "czechia": "CZE",
+    "dominican republic": "DOM",
+    "great britain": "GBR",
+    "israel": "ISR",
+    "italy": "ITA",
+    "japan": "JPN",
+    "kingdom of the netherlands": "NED",
+    "korea": "KOR",
+    "mexico": "MEX",
+    "netherlands": "NED",
+    "nicaragua": "NCA",
+    "panama": "PAN",
+    "puerto rico": "PUR",
+    "south korea": "KOR",
+    "taiwan": "TPE",
+    "united states": "USA",
+    "united states of america": "USA",
+    "venezuela": "VEN"
+  };
+
   var MLB_LOGO_FILE_ALIASES = {
     "AUS": "Australia",
     "BRA": "Brazil",
@@ -2492,10 +2520,20 @@
 
       if (league === "mlb") {
         var teamId = parseInt(team.id, 10);
+        var mlbCountryName = String(
+          team.shortDisplayName
+          || team.displayName
+          || team.teamName
+          || team.name
+          || team.clubName
+          || ""
+        ).trim().toLowerCase();
+        var intlCountryAbbr = MLB_INTERNATIONAL_ABBREVIATIONS_BY_COUNTRY_NAME[mlbCountryName] || "";
         var intlAbbr = Number.isFinite(teamId)
           ? MLB_INTERNATIONAL_ABBREVIATIONS_BY_TEAM_ID[teamId]
           : "";
         abbr = intlAbbr
+          || intlCountryAbbr
           || MLB_ABBREVIATIONS[name]
           || team.abbreviation
           || team.teamAbbreviation


### PR DESCRIPTION
### Motivation

- WBC / international MLB entries were not resolving to the correct flag assets under `images/mlb/` because some entries lack stable numeric MLB team IDs or use country names in display fields. 
- The goal is to map those country-name display values to canonical three-letter abbreviations so `getLogoUrl` picks the correct `images/mlb/<Country>.png` file.

### Description

- Added a new lookup table `MLB_INTERNATIONAL_ABBREVIATIONS_BY_COUNTRY_NAME` that maps normalized country/display names to three-letter abbreviations. 
- Updated `_abbrForTeam` in `MMM-Scores.js` to normalize `team.shortDisplayName`, `team.displayName`, `team.teamName`, `team.name`, and `team.clubName` to a lowercase token and consult the new mapping before falling back to existing ID- and name-based logic. 
- This causes `getLogoUrl` to build `images/mlb/<Country>.png` paths for WBC/international teams when appropriate, improving flag resolution for international teams.

### Testing

- Ran `node --check MMM-Scores.js` to validate syntax, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa4915f43c8322a2739f39adcfb7f0)