### PR TITLE
Group and sort MLB games by MLB/WBC matchup tiers

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -63,6 +63,23 @@ const fetch = (typeof global.fetch === "function")
 
 const SUPPORTED_LEAGUES = ["mlb", "nhl", "nfl", "nba", "olympic_mhockey", "olympic_whockey"];
 const MLB_SCOREBOARD_SPORT_IDS = [1, 51]; // MLB + World Baseball Classic
+const MLB_INTERNATIONAL_WBC_TEAM_IDS = new Set([
+  776, // Brazil
+  784, // Canada
+  792, // Colombia
+  798, // Cuba
+  805, // Dominican Republic
+  821, // Great Britain
+  840, // Israel
+  841, // Italy
+  867, // Mexico
+  878, // Kingdom of the Netherlands
+  881, // Nicaragua
+  890, // Panama
+  897, // Puerto Rico
+  940, // United States
+  944 // Venezuela
+]);
 
 const DNS_LOOKUP = (dns && dns.promises && typeof dns.promises.lookup === "function")
   ? (host) => dns.promises.lookup(host)
@@ -148,6 +165,9 @@ module.exports = NodeHelper.create({
       }
 
       const games = Array.from(gamesByPk.values()).sort((a, b) => {
+        const tierDiff = this._getMlbGameSortTier(a) - this._getMlbGameSortTier(b);
+        if (tierDiff !== 0) return tierDiff;
+
         const aDate = Date.parse((a && a.gameDate) || "") || 0;
         const bDate = Date.parse((b && b.gameDate) || "") || 0;
         return aDate - bDate;
@@ -181,6 +201,26 @@ module.exports = NodeHelper.create({
     }
 
     return games;
+  },
+
+  _getMlbGameSortTier(game) {
+    const internationalTeams = this._countInternationalWbcTeams(game);
+    if (internationalTeams <= 0) return 0; // MLB vs MLB
+    if (internationalTeams === 1) return 1; // MLB vs WBC
+    return 2; // WBC vs WBC
+  },
+
+  _countInternationalWbcTeams(game) {
+    if (!game || !game.teams) return 0;
+
+    let count = 0;
+    const awayTeamId = Number(game.teams?.away?.team?.id);
+    const homeTeamId = Number(game.teams?.home?.team?.id);
+
+    if (MLB_INTERNATIONAL_WBC_TEAM_IDS.has(awayTeamId)) count += 1;
+    if (MLB_INTERNATIONAL_WBC_TEAM_IDS.has(homeTeamId)) count += 1;
+
+    return count;
   },
 
   async _fetchNhlGames() {


### PR DESCRIPTION
### Motivation
- Ensure MLB scoreboard lists games in the requested order: MLB-only first, then games with exactly one WBC/international team, then WBC-only matchups.  
- Preserve chronological ordering (by start time) within each of those groupings for predictable display.  

### Description
- Added `MLB_INTERNATIONAL_WBC_TEAM_IDS` as a canonical `Set` of international/WBC MLB team IDs used for classification.  
- Updated `_fetchMlbGames` sorting to first compare a matchup `tier` (MLB-only = 0, one international WBC team = 1, two international WBC teams = 2) and then fall back to `gameDate` for chronological ordering.  
- Introduced helper methods `_getMlbGameSortTier` and `_countInternationalWbcTeams` to compute each game’s tier based on away/home team IDs.  

### Testing
- Ran `node --check node_helper.js` which completed with no syntax errors.  
- Ran `npm run test:api` which failed due to network/DNS connectivity to upstream APIs in this environment and therefore reported external network failures (not code syntax issues).  
- No other automated tests were run; runtime behavior should be exercised in an environment with API access to validate end-to-end ordering on the frontend.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab1bb443e88322826dc537ceb55b2e)