### PR TITLE
Adjust MLB final status text for shortened and extra-inning games

### DIFF
--- a/MMM-Scores.js
+++ b/MMM-Scores.js
@@ -1687,7 +1687,14 @@
       else if (isPrev) {
         statusText = this._formatStartTime(game && game.gameDate);
       } else if (isFin) {
-        statusText = (innings.length === 9) ? "Final" : ("Final/" + innings.length);
+        var finalInnings = this._firstNumber(
+          ls && ls.currentInning,
+          ls && ls.scheduledInnings,
+          innings.length
+        );
+        statusText = (finalInnings == null || finalInnings === 9)
+          ? "Final"
+          : ("Final/" + finalInnings);
       } else {
         var st = (ls && ls.inningState) || "";
         var io = (ls && ls.currentInningOrdinal) || "";


### PR DESCRIPTION
### Motivation
- Ensure MLB games that finish in fewer or more than 9 innings show the ending inning in the status (for example `Final/7` or `Final/11`) instead of always relying on the raw `innings.length` value.

### Description
- In `_createMlbGameCard` compute `finalInnings` using `this._firstNumber(ls && ls.currentInning, ls && ls.scheduledInnings, innings.length)` and set `statusText` to `"Final"` when `finalInnings` is `null` or `9`, otherwise set it to `"Final/<finalInnings>"`.

### Testing
- Ran `node --check MMM-Scores.js` to verify the file parses correctly and the syntax check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aca704d6748322a8ab41fab03164e9)