### PR TITLE
Split MLB international games into automatic WBC scoreboard

### DIFF
--- a/MMM-Scores.js
+++ b/MMM-Scores.js
@@ -256,7 +256,7 @@
 
   var EXTENDED_LAYOUT_LEAGUES = { nfl: true, nhl: true, nba: true, olympic_mhockey: true, olympic_whockey: true };
 
-  var SUPPORTED_LEAGUES = ["mlb", "nhl", "nfl", "nba", "olympic_mhockey", "olympic_whockey"];
+  var SUPPORTED_LEAGUES = ["mlb", "wbc", "nhl", "nfl", "nba", "olympic_mhockey", "olympic_whockey"];
   var MLB_MAX_GAMES_PER_PAGE = 8;
   var MLB_MAX_COLUMNS        = 2;
 
@@ -289,6 +289,7 @@
       if (!this.config.showTitle) return null;
       var league = this._getLeague();
       if (league === "mlb") return "MLB Scoreboard";
+      if (league === "wbc") return "WBC Scoreboard";
       if (league === "nhl") return "NHL Scoreboard";
       if (league === "nfl") return "NFL Scoreboard";
       if (league === "nba") return "NBA Scoreboard";
@@ -503,7 +504,48 @@
       var source = (typeof cfg.leagues !== "undefined") ? cfg.leagues : cfg.league;
       var leagues = this._coerceLeagueArray(source);
       if (!Array.isArray(leagues)) return [];
-      return this._filterSeasonalLeagues(leagues);
+      return this._filterSeasonalLeagues(this._expandMlbLeagueFamily(leagues));
+    },
+
+    _expandMlbLeagueFamily: function (leagues) {
+      if (!Array.isArray(leagues) || leagues.length === 0) return [];
+
+      var expanded = [];
+      for (var i = 0; i < leagues.length; i++) {
+        var league = leagues[i];
+        if (expanded.indexOf(league) === -1) expanded.push(league);
+        if (league === "mlb" && expanded.indexOf("wbc") === -1) {
+          expanded.push("wbc");
+        }
+      }
+
+      return expanded;
+    },
+
+    _rebuildLeagueRotation: function (preferredLeague) {
+      var configured = this._resolveConfiguredLeagues();
+      if (!Array.isArray(configured) || configured.length === 0) configured = ["mlb"];
+
+      var nextRotation = [];
+      for (var i = 0; i < configured.length; i++) {
+        var league = configured[i];
+        if (league === "wbc") {
+          var wbcGames = (this.gamesByLeague && Array.isArray(this.gamesByLeague.wbc))
+            ? this.gamesByLeague.wbc
+            : [];
+          if (wbcGames.length === 0) continue;
+        }
+        nextRotation.push(league);
+      }
+
+      if (nextRotation.length === 0) nextRotation = [configured[0]];
+
+      this._leagueRotation = nextRotation;
+
+      var desiredLeague = this._normalizeLeagueKey(preferredLeague) || this._getLeague();
+      var nextIndex = this._leagueRotation.indexOf(desiredLeague);
+      if (nextIndex === -1) nextIndex = 0;
+      this._activeLeagueIndex = nextIndex;
     },
 
     _todayIsoInTimeZone: function () {
@@ -651,12 +693,14 @@
     _maximumGamesPerPageForLeague: function (league) {
       if (!league) league = this._getLeague();
       if (league === "mlb") return MLB_MAX_GAMES_PER_PAGE;
+      if (league === "wbc") return MLB_MAX_GAMES_PER_PAGE;
       return null;
     },
 
     _maximumColumnsForLeague: function (league) {
       if (!league) league = this._getLeague();
       if (league === "mlb") return MLB_MAX_COLUMNS;
+      if (league === "wbc") return MLB_MAX_COLUMNS;
       return null;
     },
 
@@ -1147,12 +1191,7 @@
             delete this.extrasByLeague[league];
           }
 
-          if (!Array.isArray(this._leagueRotation) || this._leagueRotation.length === 0) {
-            this._leagueRotation = [league];
-            this._activeLeagueIndex = 0;
-          } else if (this._leagueRotation.indexOf(league) === -1) {
-            this._leagueRotation.push(league);
-          }
+          this._rebuildLeagueRotation(league);
 
           this._applyActiveLeagueState();
           this.updateDom();

--- a/node_helper.js
+++ b/node_helper.js
@@ -61,7 +61,7 @@ const fetch = (typeof global.fetch === "function")
   ? global.fetch.bind(global)
   : createHttpFetchFallback();
 
-const SUPPORTED_LEAGUES = ["mlb", "nhl", "nfl", "nba", "olympic_mhockey", "olympic_whockey"];
+const SUPPORTED_LEAGUES = ["mlb", "wbc", "nhl", "nfl", "nba", "olympic_mhockey", "olympic_whockey"];
 const MLB_SCOREBOARD_SPORT_IDS = [1, 51]; // MLB + World Baseball Classic
 const MLB_INTERNATIONAL_WBC_TEAM_IDS = new Set([
   776, // Brazil
@@ -173,12 +173,35 @@ module.exports = NodeHelper.create({
         return aDate - bDate;
       });
 
-      console.log(`⚾️ Sending ${games.length} MLB games to front-end.`);
-      this._notifyGames("mlb", games);
+      const separatedGames = this._splitMlbAndWbcGames(games);
+
+      console.log(`⚾️ Sending ${separatedGames.mlb.length} MLB games to front-end.`);
+      this._notifyGames("mlb", separatedGames.mlb);
+      this._notifyGames("wbc", separatedGames.wbc);
     } catch (e) {
       console.error("🚨 MLB fetchGames failed:", e);
       this._notifyGames("mlb", []);
+      this._notifyGames("wbc", []);
     }
+  },
+
+
+
+  _splitMlbAndWbcGames(games) {
+    const mlb = [];
+    const wbc = [];
+
+    for (let i = 0; i < games.length; i += 1) {
+      const game = games[i];
+      if (this._isInternationalWbcGame(game)) wbc.push(game);
+      else mlb.push(game);
+    }
+
+    return { mlb, wbc };
+  },
+
+  _isInternationalWbcGame(game) {
+    return this._countInternationalWbcTeams(game) >= 2;
   },
 
   async _fetchMlbGamesBySport(dateIso, sportId) {
@@ -2067,7 +2090,22 @@ module.exports = NodeHelper.create({
     const source = (typeof cfg.leagues !== "undefined") ? cfg.leagues : cfg.league;
     const leagues = this._coerceLeagueArray(source);
     if (!Array.isArray(leagues)) return [];
-    return this._filterSeasonalLeagues(leagues);
+    return this._filterSeasonalLeagues(this._expandMlbLeagueFamily(leagues));
+  },
+
+
+
+  _expandMlbLeagueFamily(leagues) {
+    if (!Array.isArray(leagues) || leagues.length === 0) return [];
+
+    const expanded = [];
+    for (let i = 0; i < leagues.length; i += 1) {
+      const league = leagues[i];
+      if (!expanded.includes(league)) expanded.push(league);
+      if (league === "mlb" && !expanded.includes("wbc")) expanded.push("wbc");
+    }
+
+    return expanded;
   },
 
   _todayIsoInTimeZone() {


### PR DESCRIPTION
### Motivation
- Move international (WBC) matchups out of the MLB scoreboard into their own scoreboard titled `WBC Scoreboard` while keeping this behavior internal to the MLB flow so no `config.js` edits are required.
- Ensure the WBC scoreboard only appears when there are international games and is omitted entirely when none exist.

### Description
- Added a new internal league key `wbc` to supported leagues and mapped it to a header title `WBC Scoreboard` in the front-end (`MMM-Scores.js`).
- Automatically expand configured `mlb` into the `mlb`+`wbc` family via `_expandMlbLeagueFamily`, and rebuilt the league rotation with `_rebuildLeagueRotation` so `wbc` is included only when it has games; applied MLB layout caps to `wbc` (`_maximumGamesPerPageForLeague` and `_maximumColumnsForLeague`).
- Updated the backend helper (`node_helper.js`) to split fetched MLB games into `mlb` (domestic/non-international) and `wbc` (international vs international) using `_splitMlbAndWbcGames` and `_isInternationalWbcGame`, and publish both `mlb` and `wbc` payloads (and clear both on fetch failure).
- Hooked the front-end to use the rebuilt rotation so the WBC board is suppressed when its games array is empty and appears automatically when present.

### Testing
- Ran `node --check MMM-Scores.js` and `node --check node_helper.js` with no syntax errors.
- Ran `npm run test:api`, which failed in this environment due to outbound network/DNS restrictions (ENETUNREACH / ENOTFOUND), so live API connectivity checks could not complete.
- Confirmed the module-level smoke flow locally by static inspection of the updated league/notification paths and layout cap logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad9ca2ffa88322a195984fa44825bf)