### PR TITLE
Fix WBC classification for international team name variants

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -80,6 +80,33 @@ const MLB_INTERNATIONAL_WBC_TEAM_IDS = new Set([
   940, // United States
   944 // Venezuela
 ]);
+const MLB_INTERNATIONAL_WBC_TEAM_NAMES = new Set([
+  "australia",
+  "brazil",
+  "canada",
+  "chinese taipei",
+  "colombia",
+  "cuba",
+  "czech republic",
+  "czechia",
+  "dominican republic",
+  "great britain",
+  "israel",
+  "italy",
+  "japan",
+  "kingdom of the netherlands",
+  "korea",
+  "mexico",
+  "netherlands",
+  "nicaragua",
+  "panama",
+  "puerto rico",
+  "south korea",
+  "taiwan",
+  "united states",
+  "united states of america",
+  "venezuela"
+]);
 
 const DNS_LOOKUP = (dns && dns.promises && typeof dns.promises.lookup === "function")
   ? (host) => dns.promises.lookup(host)
@@ -237,13 +264,28 @@ module.exports = NodeHelper.create({
     if (!game || !game.teams) return 0;
 
     let count = 0;
-    const awayTeamId = Number(game.teams?.away?.team?.id);
-    const homeTeamId = Number(game.teams?.home?.team?.id);
+    const awayTeam = game.teams?.away?.team;
+    const homeTeam = game.teams?.home?.team;
 
-    if (MLB_INTERNATIONAL_WBC_TEAM_IDS.has(awayTeamId)) count += 1;
-    if (MLB_INTERNATIONAL_WBC_TEAM_IDS.has(homeTeamId)) count += 1;
+    if (this._isInternationalWbcTeam(awayTeam)) count += 1;
+    if (this._isInternationalWbcTeam(homeTeam)) count += 1;
 
     return count;
+  },
+
+  _isInternationalWbcTeam(team) {
+    const teamId = Number(team?.id);
+    if (MLB_INTERNATIONAL_WBC_TEAM_IDS.has(teamId)) return true;
+
+    const normalizedName = String(
+      team?.shortDisplayName
+      || team?.displayName
+      || team?.teamName
+      || team?.name
+      || ""
+    ).trim().toLowerCase();
+
+    return MLB_INTERNATIONAL_WBC_TEAM_NAMES.has(normalizedName);
   },
 
   async _fetchNhlGames() {


### PR DESCRIPTION
### Motivation
- Some international-vs-international games were being classified as MLB because their team IDs were not present in the hardcoded WBC team ID list. 
- Add a name-based fallback so games between national teams are routed to the WBC screen even when IDs are missing or differ in the API payload.

### Description
- Added a normalized `MLB_INTERNATIONAL_WBC_TEAM_NAMES` set to `node_helper.js` containing country/team name variants used by the MLB/WBC API. 
- Refactored `_countInternationalWbcTeams` to extract the away/home team objects and delegate detection to a new `_isInternationalWbcTeam` helper. 
- Implemented `_isInternationalWbcTeam` to return true if a team ID is in `MLB_INTERNATIONAL_WBC_TEAM_IDS` or if the normalized team name appears in `MLB_INTERNATIONAL_WBC_TEAM_NAMES` using `shortDisplayName`, `displayName`, `teamName`, or `name` fields.

### Testing
- Ran `node --check node_helper.js && node --check MMM-Scores.js` and both files passed the Node syntax checks. 
- Ran `npm run test:api`, which failed due to outbound network restrictions (`ENETUNREACH` / fetch failures) in the environment and not due to code syntax or logic errors. 
- Verified the repository diff and committed the change to `node_helper.js` locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad9f5275ac832282566665585396f3)