### PR TITLE
Reduce MLB/WBC R-H-E column spacing by 20%

### DIFF
--- a/MMM-Scores.css
+++ b/MMM-Scores.css
@@ -241,6 +241,25 @@
   column-gap: var(--scoreboard-gap);
 }
 
+.scoreboard-card.league-mlb,
+.scoreboard-card.league-wbc {
+  --scoreboard-mlb-rhe-gap-reduction: 0.2;
+}
+
+.scoreboard-card.league-mlb .scoreboard-header .scoreboard-label:nth-of-type(2),
+.scoreboard-card.league-wbc .scoreboard-header .scoreboard-label:nth-of-type(2),
+.scoreboard-card.league-mlb .scoreboard-row .scoreboard-value:nth-of-type(2),
+.scoreboard-card.league-wbc .scoreboard-row .scoreboard-value:nth-of-type(2) {
+  margin-left: calc(var(--scoreboard-gap) * var(--scoreboard-mlb-rhe-gap-reduction) * -1);
+}
+
+.scoreboard-card.league-mlb .scoreboard-header .scoreboard-label:nth-of-type(3),
+.scoreboard-card.league-wbc .scoreboard-header .scoreboard-label:nth-of-type(3),
+.scoreboard-card.league-mlb .scoreboard-row .scoreboard-value:nth-of-type(3),
+.scoreboard-card.league-wbc .scoreboard-row .scoreboard-value:nth-of-type(3) {
+  margin-left: calc(var(--scoreboard-gap) * var(--scoreboard-mlb-rhe-gap-reduction) * -2);
+}
+
 .scoreboard-card .scoreboard-header {
   background: var(--scoreboard-header-bg);
   padding: var(--scoreboard-pad-block) var(--scoreboard-pad-inline);


### PR DESCRIPTION
### Motivation
- Tighten the horizontal spacing on MLB and WBC scoreboard cards to reduce visual gap between the R, H, and E columns by 20%. 
- The adjustment should be presentation-only and apply only to MLB/WBC so other league layouts remain unchanged.

### Description
- Added a league-scoped CSS variable `--scoreboard-mlb-rhe-gap-reduction: 0.2` in `MMM-Scores.css` scoped to `.scoreboard-card.league-mlb` and `.scoreboard-card.league-wbc`.
- Shifted the H column left by applying a negative `margin-left` to the second metric (`:nth-of-type(2)`) for both header labels and row values in MLB/WBC cards.
- Shifted the E column further left by applying a larger negative `margin-left` to the third metric (`:nth-of-type(3)`) for both header labels and row values in MLB/WBC cards.
- This is purely a CSS presentation change (no parsing or JS rendering logic was modified) and only affects MLB and WBC scoreboards.

### Testing
- Ran `node --check MMM-Scores.js` to verify no JavaScript syntax issues, and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ada141e2b883229ac68cc9a371a66f)