### PR TITLE
Preserve active league when rebuilding rotation on GAMES updates

### DIFF
--- a/MMM-Scores.js
+++ b/MMM-Scores.js
@@ -1191,7 +1191,8 @@
             delete this.extrasByLeague[league];
           }
 
-          this._rebuildLeagueRotation(league);
+          var activeLeagueBeforeUpdate = this._getLeague();
+          this._rebuildLeagueRotation(activeLeagueBeforeUpdate);
 
           this._applyActiveLeagueState();
           this.updateDom();


### PR DESCRIPTION
### Motivation
- Prevent the UI from jumping to whichever league’s payload arrived last (causing brief flashes of WBC/NHL before immediately showing NBA); preserve the currently displayed league when new `GAMES` socket payloads arrive; no external skill was used.

### Description
- Capture the currently active league with `this._getLeague()` and pass it into `_rebuildLeagueRotation(...)` so the rotation is rebuilt around the league currently being displayed instead of the league in the incoming payload.

### Testing
- Ran static check with `node --check MMM-Scores.js`, which succeeded.
- Ran `npm run test:api`, which reported network/DNS failures for external API endpoints in this environment and therefore failed for environmental reasons rather than code logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ada27e585c8322a126156feb802c6e)