### PR TITLE
Show "Delayed" status for MLB and WBC games

### DIFF
--- a/MMM-Scores.js
+++ b/MMM-Scores.js
@@ -1714,15 +1714,17 @@
 
       var isSuspended = /Suspended/i.test(det) || state === "Suspended";
       var isPost      = /Postponed/i.test(det);
+      var isDelayed   = /\bdelay(?:ed)?\b/i.test(det) || /\bdelay(?:ed)?\b/i.test(state);
       var isWarmup    = det === "Warmup";
       var isPrev      = state === "Preview";
       var isFin       = state === "Final";
-      var live        = !isPrev && !isFin && !isPost && !isWarmup && !isSuspended;
+      var live        = !isPrev && !isFin && !isPost && !isDelayed && !isWarmup && !isSuspended;
       var showVals    = !isPrev && !isPost && !isSuspended;
 
       var statusText;
       if (isSuspended)       statusText = "Suspended";
       else if (isPost)       statusText = "Postponed";
+      else if (isDelayed)    statusText = "Delayed";
       else if (isWarmup)     statusText = "Warmup";
       else if (isPrev) {
         statusText = this._formatStartTime(game && game.gameDate);


### PR DESCRIPTION
### Motivation
- The MLB/WBC scoreboard card logic treated delay states from the feed as generic live or unknown states, and the module should display `Delayed` when the feed reports `Delay` or `Delayed`.
- Delay states should also prevent the card from being marked as live so styling/values are correct.

### Description
- Added a delay detection check using `\bdelay(?:ed)?\b` against the detailed and abstract state fields in `MMM-Scores.js` (MLB card builder).
- Set the scoreboard `statusText` to `Delayed` when a delay is detected and excluded delayed games from being considered `live` for card classes.
- Change applies to the MLB card creation path which is also used for WBC games, so both leagues will display `Delayed`.

### Testing
- Ran `node --check MMM-Scores.js`, which succeeded without syntax errors.
- Ran `npm run test:olympic` (existing test script); the script executed but external provider fetches failed in this environment, causing those checks to report failures unrelated to the local change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af59c74afc8322bed8417c5c3c4b05)