### PR TITLE
Handle canceled MLB games in game cards

### DIFF
--- a/MMM-Scores.js
+++ b/MMM-Scores.js
@@ -1713,16 +1713,18 @@
       var innings = (ls && ls.innings) || [];
 
       var isSuspended = /Suspended/i.test(det) || state === "Suspended";
+      var isCanceled  = /Cancel(?:ed|led)/i.test(det) || /cancel(?:ed|led)/i.test(state);
       var isPost      = /Postponed/i.test(det);
       var isDelayed   = /\bdelay(?:ed)?\b/i.test(det) || /\bdelay(?:ed)?\b/i.test(state);
       var isWarmup    = det === "Warmup";
       var isPrev      = state === "Preview";
       var isFin       = state === "Final";
-      var live        = !isPrev && !isFin && !isPost && !isDelayed && !isWarmup && !isSuspended;
-      var showVals    = !isPrev && !isPost && !isSuspended;
+      var live        = !isPrev && !isFin && !isPost && !isDelayed && !isWarmup && !isSuspended && !isCanceled;
+      var showVals    = !isPrev && !isPost && !isSuspended && !isCanceled;
 
       var statusText;
       if (isSuspended)       statusText = "Suspended";
+      else if (isCanceled)   statusText = "Canceled";
       else if (isPost)       statusText = "Postponed";
       else if (isDelayed)    statusText = "Delayed";
       else if (isWarmup)     statusText = "Warmup";
@@ -1748,6 +1750,7 @@
       if (isFin) cardClasses.push("is-final");
       else if (live) cardClasses.push("is-live");
       else if (isPrev) cardClasses.push("is-preview");
+      else if (isCanceled) cardClasses.push("is-canceled");
       else if (isPost) cardClasses.push("is-postponed");
       else if (isSuspended) cardClasses.push("is-suspended");
       else if (isWarmup) cardClasses.push("is-warmup");


### PR DESCRIPTION
### Motivation
- Ensure MLB games that are canceled are treated distinctly from postponed/delayed/suspended games so UI does not show live or scored values for canceled contests.

### Description
- Add detection of canceled games via `isCanceled` using `/Cancel(?:ed|led)/i` and `/cancel(?:ed|led)/i` checks on `detailedState` and `abstractGameState`.
- Exclude canceled games from `live` and `showVals` by adding `!isCanceled` to those conditions.
- Set `statusText` to `"Canceled"` when `isCanceled` is true and add an `is-canceled` CSS class to the card (`cardClasses.push("is-canceled")`).

### Testing
- Ran `npm run lint` and `npm test` against the project; both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b77cb36e488322a0f0a65e9042e9ec)