### PR TITLE
Add MLB inning base/out indicator to scoreboard header

### DIFF
--- a/MMM-Scores.css
+++ b/MMM-Scores.css
@@ -246,15 +246,15 @@
   --scoreboard-mlb-rhe-gap-reduction: 0.2;
 }
 
-.scoreboard-card.league-mlb .scoreboard-header .scoreboard-label:nth-of-type(2),
-.scoreboard-card.league-wbc .scoreboard-header .scoreboard-label:nth-of-type(2),
+.scoreboard-card.league-mlb .scoreboard-header .scoreboard-label:nth-last-child(2),
+.scoreboard-card.league-wbc .scoreboard-header .scoreboard-label:nth-last-child(2),
 .scoreboard-card.league-mlb .scoreboard-row .scoreboard-value:nth-of-type(2),
 .scoreboard-card.league-wbc .scoreboard-row .scoreboard-value:nth-of-type(2) {
   margin-left: calc(var(--scoreboard-gap) * var(--scoreboard-mlb-rhe-gap-reduction) * -1);
 }
 
-.scoreboard-card.league-mlb .scoreboard-header .scoreboard-label:nth-of-type(3),
-.scoreboard-card.league-wbc .scoreboard-header .scoreboard-label:nth-of-type(3),
+.scoreboard-card.league-mlb .scoreboard-header .scoreboard-label:last-child,
+.scoreboard-card.league-wbc .scoreboard-header .scoreboard-label:last-child,
 .scoreboard-card.league-mlb .scoreboard-row .scoreboard-value:nth-of-type(3),
 .scoreboard-card.league-wbc .scoreboard-row .scoreboard-value:nth-of-type(3) {
   margin-left: calc(var(--scoreboard-gap) * var(--scoreboard-mlb-rhe-gap-reduction) * -2);
@@ -492,6 +492,69 @@
 .scoreboard-card.league-mlb .scoreboard-header,
 .scoreboard-card.league-mlb .scoreboard-row {
   column-gap: calc(var(--scoreboard-gap) * 0.18);
+}
+
+.scoreboard-card .scoreboard-mlb-inning-indicator {
+  justify-self: start;
+  display: flex;
+  align-items: center;
+  gap: calc(var(--scoreboard-gap) * 0.32);
+  margin-left: calc(var(--scoreboard-gap) * 0.15);
+  margin-right: calc(var(--scoreboard-gap) * 0.4);
+}
+
+.scoreboard-card .scoreboard-mlb-bases {
+  display: grid;
+  grid-template-columns: repeat(2, calc(var(--scoreboard-status-font) * 0.46));
+  grid-template-rows: repeat(2, calc(var(--scoreboard-status-font) * 0.46));
+  gap: calc(var(--scoreboard-gap) * 0.08);
+}
+
+.scoreboard-card .scoreboard-mlb-base {
+  width: calc(var(--scoreboard-status-font) * 0.38);
+  height: calc(var(--scoreboard-status-font) * 0.38);
+  border: calc(var(--box-scale) * 1px) solid var(--scoreboard-text);
+  transform: rotate(45deg);
+  background: transparent;
+  justify-self: center;
+  align-self: center;
+}
+
+.scoreboard-card .scoreboard-mlb-base.base-second {
+  grid-column: 1 / span 2;
+  grid-row: 1;
+}
+
+.scoreboard-card .scoreboard-mlb-base.base-third {
+  grid-column: 1;
+  grid-row: 2;
+}
+
+.scoreboard-card .scoreboard-mlb-base.base-first {
+  grid-column: 2;
+  grid-row: 2;
+}
+
+.scoreboard-card .scoreboard-mlb-base.occupied {
+  background: #ffd242;
+}
+
+.scoreboard-card .scoreboard-mlb-outs {
+  display: flex;
+  align-items: center;
+  gap: calc(var(--scoreboard-gap) * 0.18);
+  padding-top: calc(var(--scoreboard-gap) * 0.22);
+}
+
+.scoreboard-card .scoreboard-mlb-out-dot {
+  width: calc(var(--scoreboard-status-font) * 0.34);
+  height: calc(var(--scoreboard-status-font) * 0.34);
+  border-radius: 50%;
+  background: rgba(255, 59, 28, 0.22);
+}
+
+.scoreboard-card .scoreboard-mlb-out-dot.active {
+  background: #ff3b1c;
 }
 
 .scoreboard-card.league-mlb .scoreboard-header {

--- a/MMM-Scores.js
+++ b/MMM-Scores.js
@@ -1523,6 +1523,9 @@
         statusEl.appendChild(totalLabelEl);
       }
       header.appendChild(statusEl);
+      if (config && config.statusIndicator) {
+        header.appendChild(config.statusIndicator);
+      }
 
       for (var li = 0; li < metricLabels.length; li++) {
         var label = document.createElement("div");
@@ -1705,6 +1708,53 @@
       return label;
     },
 
+    _createMlbInningIndicator: function (linescore) {
+      var ls = linescore || {};
+      var offense = (ls && ls.offense) || {};
+
+      var hasRunnerOnFirst = !!offense.first;
+      var hasRunnerOnSecond = !!offense.second;
+      var hasRunnerOnThird = !!offense.third;
+
+      var outsRaw = this._firstNumber(ls && ls.outs, 0);
+      var outs = Math.max(0, Math.min(2, outsRaw == null ? 0 : outsRaw));
+
+      var indicator = document.createElement("div");
+      indicator.className = "scoreboard-mlb-inning-indicator";
+
+      var bases = document.createElement("div");
+      bases.className = "scoreboard-mlb-bases";
+
+      var firstBase = document.createElement("span");
+      firstBase.className = "scoreboard-mlb-base base-first";
+      if (hasRunnerOnFirst) firstBase.classList.add("occupied");
+
+      var secondBase = document.createElement("span");
+      secondBase.className = "scoreboard-mlb-base base-second";
+      if (hasRunnerOnSecond) secondBase.classList.add("occupied");
+
+      var thirdBase = document.createElement("span");
+      thirdBase.className = "scoreboard-mlb-base base-third";
+      if (hasRunnerOnThird) thirdBase.classList.add("occupied");
+
+      bases.appendChild(secondBase);
+      bases.appendChild(thirdBase);
+      bases.appendChild(firstBase);
+      indicator.appendChild(bases);
+
+      var outsWrap = document.createElement("div");
+      outsWrap.className = "scoreboard-mlb-outs";
+      for (var oi = 0; oi < 2; oi++) {
+        var dot = document.createElement("span");
+        dot.className = "scoreboard-mlb-out-dot";
+        if (oi < outs) dot.classList.add("active");
+        outsWrap.appendChild(dot);
+      }
+      indicator.appendChild(outsWrap);
+
+      return indicator;
+    },
+
     _createMlbGameCard: function (game) {
       var league = "mlb";
       var ls      = (game && game.linescore) || {};
@@ -1805,6 +1855,7 @@
         live: live,
         showValues: showVals,
         statusText: statusText,
+        statusIndicator: live ? this._createMlbInningIndicator(ls) : null,
         metricLabels: ["R", "H", "E"],
         rows: rows,
         cardClasses: cardClasses


### PR DESCRIPTION
### Motivation
- Provide a visual indicator for MLB games showing which bases have runners and how many outs, placed after the inning/status text and before the R/H/E metrics and aligned with the inning text.

### Description
- Added a new renderer ` _createMlbInningIndicator(linescore)` which reads `linescore.offense` for base occupancy and `linescore.outs` for up-to-two outs and returns a DOM element with base diamonds and out dots.
- Extended the generic header rendering to accept an optional `statusIndicator` element by appending `config.statusIndicator` after the inning/status element in ` _createScoreboardCard` header construction.
- Wired MLB cards to provide the indicator when the game is live by passing `statusIndicator: live ? this._createMlbInningIndicator(ls) : null` from ` _createMlbGameCard`.
- Added CSS rules in `MMM-Scores.css` to render the diamond-shaped bases (`.scoreboard-mlb-bases`, `.scoreboard-mlb-base`), yellow fill for occupied bases (`.occupied`), red outs dots (`.scoreboard-mlb-out-dot` / `.active`), spacing/vertical alignment for `.scoreboard-mlb-inning-indicator`, and adjusted header label selectors (`:nth-last-child(2)` / `:last-child`) so R/H/E alignment remains correct when the extra indicator is present.

### Testing
- Ran `npm run test:api`, which could not complete due to network connectivity errors to external APIs (tests failed with `ENETUNREACH` / `ENOTFOUND` / `fetch failed`), so failures are environmental and not indicative of the UI changes.
- Ran `npm run test:olympic`, which executed but external fetches failed for the same network reasons and returned no remote games; the script itself ran without local runtime errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3d77ee7908322a216b7f873358b3f)