### PR TITLE
Add MLB inning/bases indicator and integrate into scoreboard header; adjust MLB header selectors

### DIFF
--- a/MMM-Scores.css
+++ b/MMM-Scores.css
@@ -246,15 +246,15 @@
   --scoreboard-mlb-rhe-gap-reduction: 0.2;
 }
 
-.scoreboard-card.league-mlb .scoreboard-header .scoreboard-label:nth-of-type(2),
-.scoreboard-card.league-wbc .scoreboard-header .scoreboard-label:nth-of-type(2),
+.scoreboard-card.league-mlb .scoreboard-header .scoreboard-label:nth-last-child(2),
+.scoreboard-card.league-wbc .scoreboard-header .scoreboard-label:nth-last-child(2),
 .scoreboard-card.league-mlb .scoreboard-row .scoreboard-value:nth-of-type(2),
 .scoreboard-card.league-wbc .scoreboard-row .scoreboard-value:nth-of-type(2) {
   margin-left: calc(var(--scoreboard-gap) * var(--scoreboard-mlb-rhe-gap-reduction) * -1);
 }
 
-.scoreboard-card.league-mlb .scoreboard-header .scoreboard-label:nth-of-type(3),
-.scoreboard-card.league-wbc .scoreboard-header .scoreboard-label:nth-of-type(3),
+.scoreboard-card.league-mlb .scoreboard-header .scoreboard-label:last-child,
+.scoreboard-card.league-wbc .scoreboard-header .scoreboard-label:last-child,
 .scoreboard-card.league-mlb .scoreboard-row .scoreboard-value:nth-of-type(3),
 .scoreboard-card.league-wbc .scoreboard-row .scoreboard-value:nth-of-type(3) {
   margin-left: calc(var(--scoreboard-gap) * var(--scoreboard-mlb-rhe-gap-reduction) * -2);
@@ -492,6 +492,68 @@
 .scoreboard-card.league-mlb .scoreboard-header,
 .scoreboard-card.league-mlb .scoreboard-row {
   column-gap: calc(var(--scoreboard-gap) * 0.18);
+}
+
+.scoreboard-card .scoreboard-mlb-inning-indicator {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  gap: calc(var(--scoreboard-gap) * 0.28);
+  margin-left: calc(var(--scoreboard-gap) * 0.45);
+}
+
+.scoreboard-card .scoreboard-mlb-bases {
+  position: relative;
+  width: calc(var(--scoreboard-status-font) * 1.2);
+  height: calc(var(--scoreboard-status-font) * 0.96);
+}
+
+.scoreboard-card .scoreboard-mlb-base {
+  position: absolute;
+  width: calc(var(--scoreboard-status-font) * 0.38);
+  height: calc(var(--scoreboard-status-font) * 0.38);
+  border: calc(var(--box-scale) * 1px) solid var(--scoreboard-text);
+  transform: rotate(45deg);
+  background: transparent;
+  transform-origin: center;
+}
+
+.scoreboard-card .scoreboard-mlb-base.base-second {
+  top: 0;
+  left: 50%;
+  margin-left: calc(var(--scoreboard-status-font) * -0.19);
+}
+
+.scoreboard-card .scoreboard-mlb-base.base-third {
+  bottom: calc(var(--scoreboard-status-font) * 0.05);
+  left: calc(var(--scoreboard-status-font) * 0.07);
+}
+
+.scoreboard-card .scoreboard-mlb-base.base-first {
+  bottom: calc(var(--scoreboard-status-font) * 0.05);
+  right: calc(var(--scoreboard-status-font) * 0.07);
+}
+
+.scoreboard-card .scoreboard-mlb-base.occupied {
+  background: #ffd242;
+}
+
+.scoreboard-card .scoreboard-mlb-outs {
+  display: flex;
+  align-items: center;
+  gap: calc(var(--scoreboard-gap) * 0.2);
+  margin-top: calc(var(--scoreboard-gap) * 0.3);
+}
+
+.scoreboard-card .scoreboard-mlb-out-dot {
+  width: calc(var(--scoreboard-status-font) * 0.34);
+  height: calc(var(--scoreboard-status-font) * 0.34);
+  border-radius: 50%;
+  background: rgba(255, 59, 28, 0.22);
+}
+
+.scoreboard-card .scoreboard-mlb-out-dot.active {
+  background: #ff3b1c;
 }
 
 .scoreboard-card.league-mlb .scoreboard-header {

--- a/MMM-Scores.js
+++ b/MMM-Scores.js
@@ -1516,6 +1516,9 @@
       var statusEl = document.createElement("div");
       statusEl.className = "scoreboard-status" + (live ? " live" : "");
       statusEl.textContent = (config && config.statusText) ? config.statusText : "";
+      if (config && config.statusIndicator) {
+        statusEl.appendChild(config.statusIndicator);
+      }
       if (config && config.teamTotalLabel) {
         var totalLabelEl = document.createElement("span");
         totalLabelEl.className = "scoreboard-team-total-label";
@@ -1705,6 +1708,53 @@
       return label;
     },
 
+    _createMlbInningIndicator: function (linescore) {
+      var ls = linescore || {};
+      var offense = (ls && ls.offense) || {};
+
+      var hasRunnerOnFirst = !!offense.first;
+      var hasRunnerOnSecond = !!offense.second;
+      var hasRunnerOnThird = !!offense.third;
+
+      var outsRaw = this._firstNumber(ls && ls.outs, 0);
+      var outs = Math.max(0, Math.min(2, outsRaw == null ? 0 : outsRaw));
+
+      var indicator = document.createElement("div");
+      indicator.className = "scoreboard-mlb-inning-indicator";
+
+      var bases = document.createElement("div");
+      bases.className = "scoreboard-mlb-bases";
+
+      var firstBase = document.createElement("span");
+      firstBase.className = "scoreboard-mlb-base base-first";
+      if (hasRunnerOnFirst) firstBase.classList.add("occupied");
+
+      var secondBase = document.createElement("span");
+      secondBase.className = "scoreboard-mlb-base base-second";
+      if (hasRunnerOnSecond) secondBase.classList.add("occupied");
+
+      var thirdBase = document.createElement("span");
+      thirdBase.className = "scoreboard-mlb-base base-third";
+      if (hasRunnerOnThird) thirdBase.classList.add("occupied");
+
+      bases.appendChild(secondBase);
+      bases.appendChild(thirdBase);
+      bases.appendChild(firstBase);
+      indicator.appendChild(bases);
+
+      var outsWrap = document.createElement("div");
+      outsWrap.className = "scoreboard-mlb-outs";
+      for (var oi = 0; oi < 2; oi++) {
+        var dot = document.createElement("span");
+        dot.className = "scoreboard-mlb-out-dot";
+        if (oi < outs) dot.classList.add("active");
+        outsWrap.appendChild(dot);
+      }
+      indicator.appendChild(outsWrap);
+
+      return indicator;
+    },
+
     _createMlbGameCard: function (game) {
       var league = "mlb";
       var ls      = (game && game.linescore) || {};
@@ -1805,6 +1855,7 @@
         live: live,
         showValues: showVals,
         statusText: statusText,
+        statusIndicator: live ? this._createMlbInningIndicator(ls) : null,
         metricLabels: ["R", "H", "E"],
         rows: rows,
         cardClasses: cardClasses


### PR DESCRIPTION
### Motivation
- Provide a compact visual indicator showing base runners and outs on MLB game cards and ensure header label spacing targets the correct label elements for MLB/WBC layouts.

### Description
- Added CSS for an inning indicator including `.scoreboard-mlb-inning-indicator`, `.scoreboard-mlb-bases`, `.scoreboard-mlb-base`, `.scoreboard-mlb-outs`, and `.scoreboard-mlb-out-dot` with `.occupied` and `.active` states for base occupancy and outs visualization.
- Adjusted header selectors from `:nth-of-type(2)`/`(3)` to `:nth-last-child(2)` and `:last-child` for MLB/WBC to correctly target header labels when extra elements are injected.
- Updated `MMM-Scores.js` to append a `config.statusIndicator` into the header `statusEl` when provided via `statusIndicator`.
- Implemented `_createMlbInningIndicator(linescore)` to build a DOM widget that reads `linescore.offense` and `linescore.outs` to render occupied bases and up to two out dots, and wired it into `_createMlbGameCard` by passing `statusIndicator: live ? this._createMlbInningIndicator(ls) : null`.

### Testing
- No automated tests exist for this module, so no automated test suites were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3d77ee7908322a216b7f873358b3f)