### PR TITLE
Fix status indicator reparenting in scoreboard header

### DIFF
--- a/MMM-Scores.js
+++ b/MMM-Scores.js
@@ -1526,9 +1526,6 @@
         statusEl.appendChild(totalLabelEl);
       }
       header.appendChild(statusEl);
-      if (config && config.statusIndicator) {
-        header.appendChild(config.statusIndicator);
-      }
 
       for (var li = 0; li < metricLabels.length; li++) {
         var label = document.createElement("div");


### PR DESCRIPTION
### Motivation
- Prevent `config.statusIndicator` from being reparented out of the `.scoreboard-status` flex row and becoming a separate header grid cell.

### Description
- Remove the redundant `header.appendChild(config.statusIndicator)` so the indicator is only appended into `statusEl` inside `_createScoreboardCard` in `MMM-Scores.js`.

### Testing
- Ran `node --check MMM-Scores.js` and it completed with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3de68ed7c832286d4bf5e7aba860a)