### PR TITLE
Adjust MLB/WBC R-H-E header label placement

### DIFF
--- a/MMM-Scores.css
+++ b/MMM-Scores.css
@@ -560,6 +560,12 @@
   padding-bottom: calc(var(--scoreboard-pad-block) * 0.7);
 }
 
+.scoreboard-card.league-mlb .scoreboard-header .scoreboard-label,
+.scoreboard-card.league-wbc .scoreboard-header .scoreboard-label {
+  align-self: end;
+  transform: translateY(calc(var(--scoreboard-gap) * 0.42));
+}
+
 .scoreboard-card.league-mlb .scoreboard-row:first-child {
   padding-top: calc(var(--scoreboard-pad-block) * 0.7);
 }


### PR DESCRIPTION
### Motivation
- Move the MLB/WBC header metric labels (`R`, `H`, `E`) down so they sit closer to the score values and visually below the bases/outs indicator.

### Description
- Update `MMM-Scores.css` to add a rule targeting `.scoreboard-card.league-mlb .scoreboard-header .scoreboard-label` and `.scoreboard-card.league-wbc .scoreboard-header .scoreboard-label` that sets `align-self: end` and `transform: translateY(calc(var(--scoreboard-gap) * 0.42))` to lower and align the labels to the bottom of the header row.

### Testing
- Ran `npm run -s test` and `npm test`, both failed due to a missing `test` script in this repository (no automated test suite available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3e25f0730832292e979865b8ddf6f)