### PR TITLE
Align scoreboard header labels for MLB and WBC

### DIFF
--- a/MMM-Scores.css
+++ b/MMM-Scores.css
@@ -560,6 +560,12 @@
   padding-bottom: calc(var(--scoreboard-pad-block) * 0.7);
 }
 
+.scoreboard-card.league-mlb .scoreboard-header .scoreboard-label,
+.scoreboard-card.league-wbc .scoreboard-header .scoreboard-label {
+  align-self: end;
+  transform: translateY(calc(var(--scoreboard-gap) * 0.72));
+}
+
 .scoreboard-card.league-mlb .scoreboard-row:first-child {
   padding-top: calc(var(--scoreboard-pad-block) * 0.7);
 }


### PR DESCRIPTION
### Motivation
- Adjust vertical alignment of scoreboard header labels in MLB and WBC layouts so the label sits at the bottom and visually lines up with the header content.

### Description
- Added CSS rules for `.scoreboard-card.league-mlb .scoreboard-header .scoreboard-label` and `.scoreboard-card.league-wbc .scoreboard-header .scoreboard-label` to `align-self: end;` and `transform: translateY(calc(var(--scoreboard-gap) * 0.72));`.

### Testing
- No automated tests were run for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3e25f0730832292e979865b8ddf6f)