### PR TITLE
Adjust MLB scoreboard column spacing by 10%

### DIFF
--- a/MMM-Scores.css
+++ b/MMM-Scores.css
@@ -491,7 +491,7 @@
 
 .scoreboard-card.league-mlb .scoreboard-header,
 .scoreboard-card.league-mlb .scoreboard-row {
-  column-gap: calc(var(--scoreboard-gap) * 0.18);
+  column-gap: calc(var(--scoreboard-gap) * 0.162);
 }
 
 .scoreboard-card .scoreboard-mlb-inning-indicator {


### PR DESCRIPTION
### Motivation
- Tighten the horizontal spacing of metric columns in individual MLB scoreboards by reducing the column gap by 10% for a denser, more compact display.

### Description
- Updated `MMM-Scores.css` to change the rule for `.scoreboard-card.league-mlb .scoreboard-header, .scoreboard-card.league-mlb .scoreboard-row` so the `column-gap` multiplier was changed from `0.18` to `0.162` to reduce spacing by 10%.

### Testing
- Applied the change with a scripted replacement and verified the updated CSS lines using `nl -ba /workspace/MMM-Scores/MMM-Scores.css | sed -n '486,500p'` and a file diff check; the updated line is present and the checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efd97c7b28832281054b5056f6a08a)