### PR TITLE
Shorten MLB inning-state labels to Bot/Mid

### DIFF
--- a/MMM-Scores.js
+++ b/MMM-Scores.js
@@ -1793,6 +1793,9 @@
         var st = (ls && ls.inningState) || "";
         var io = (ls && ls.currentInningOrdinal) || "";
         var tmp = (st + " " + io).replace(/\s+/g, " ").trim();
+        tmp = tmp
+          .replace(/\bBottom\b/g, "Bot")
+          .replace(/\bMiddle\b/g, "Mid");
         statusText = tmp || "In Progress";
       }
 


### PR DESCRIPTION
### Motivation
- Reduce MLB scoreboard label width and improve readability by abbreviating inning-state words when rendering live in-progress status.

### Description
- In `MMM-Scores.js` adjust the MLB in-progress status formatting so the composed inning state (`st + io`) is post-processed to replace `Bottom` with `Bot` and `Middle` with `Mid` before assigning `statusText`.

### Testing
- Ran a syntax check with `node --check MMM-Scores.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f01041faac832298733b7094350753)