### PR TITLE
Fix MLB base diamond alignment symmetry

### DIFF
--- a/MMM-Scores.css
+++ b/MMM-Scores.css
@@ -503,35 +503,36 @@
 }
 
 .scoreboard-card .scoreboard-mlb-bases {
+  --scoreboard-mlb-base-size: calc(var(--scoreboard-status-font) * 0.38);
+  --scoreboard-mlb-base-step: calc(var(--scoreboard-status-font) * 0.41);
   position: relative;
-  width: calc(var(--scoreboard-status-font) * 1.2);
-  height: calc(var(--scoreboard-status-font) * 0.96);
+  width: calc(var(--scoreboard-mlb-base-size) + (var(--scoreboard-mlb-base-step) * 2));
+  height: calc(var(--scoreboard-mlb-base-size) + (var(--scoreboard-mlb-base-step) * 2));
 }
 
 .scoreboard-card .scoreboard-mlb-base {
   position: absolute;
-  width: calc(var(--scoreboard-status-font) * 0.38);
-  height: calc(var(--scoreboard-status-font) * 0.38);
+  width: var(--scoreboard-mlb-base-size);
+  height: var(--scoreboard-mlb-base-size);
   border: calc(var(--box-scale) * 1px) solid var(--scoreboard-text);
-  transform: rotate(45deg);
   background: transparent;
+  transform: translate(-50%, -50%) rotate(45deg);
   transform-origin: center;
 }
 
 .scoreboard-card .scoreboard-mlb-base.base-second {
-  top: 0;
+  top: 50%;
   left: 50%;
-  margin-left: calc(var(--scoreboard-status-font) * -0.19);
 }
 
 .scoreboard-card .scoreboard-mlb-base.base-third {
-  bottom: calc(var(--scoreboard-status-font) * 0.05);
-  left: calc(var(--scoreboard-status-font) * 0.07);
+  top: calc(50% + var(--scoreboard-mlb-base-step));
+  left: calc(50% - var(--scoreboard-mlb-base-step));
 }
 
 .scoreboard-card .scoreboard-mlb-base.base-first {
-  bottom: calc(var(--scoreboard-status-font) * 0.05);
-  right: calc(var(--scoreboard-status-font) * 0.07);
+  top: calc(50% + var(--scoreboard-mlb-base-step));
+  left: calc(50% + var(--scoreboard-mlb-base-step));
 }
 
 .scoreboard-card .scoreboard-mlb-base.occupied {


### PR DESCRIPTION
### Motivation
- The MLB bases indicator rendered as an off-center, wonky diamond at various font scales and needed to be symmetrical and consistent.

### Description
- Introduced CSS variables `--scoreboard-mlb-base-size` and `--scoreboard-mlb-base-step` and used them to compute the container `width`/`height` for predictable sizing.
- Changed base markers to use centered transforms with `transform: translate(-50%, -50%) rotate(45deg)` so each base is positioned relative to the same midpoint.
- Replaced ad-hoc top/right/bottom/left offsets with `top`/`left` values at `50%` and symmetric offsets using `var(--scoreboard-mlb-base-step)` for `.base-first`, `.base-second`, and `.base-third`.
- Updated `MMM-Scores.css` to apply the above changes so the three bases render as a balanced diamond across scales.

### Testing
- Ran the module connectivity checks with `npm run test:api`, which failed in this environment due to outbound network/DNS/connectivity errors and not because of the CSS change.
- The CSS patch was applied and committed locally (`MMM-Scores.css`), and a visual layout fix was verified by inspecting the updated rules in the file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0d8e8c9c88322bc1b37fcc60796be)