### PR TITLE
Add World Cup scoreboard support

### DIFF
--- a/MMM-Scores.js
+++ b/MMM-Scores.js
@@ -254,9 +254,9 @@
     gamesPerColumn: ["scoreboardRows", "rowsPerColumn"]
   };
 
-  var EXTENDED_LAYOUT_LEAGUES = { nfl: true, nhl: true, nba: true, olympic_mhockey: true, olympic_whockey: true };
+  var EXTENDED_LAYOUT_LEAGUES = { nfl: true, nhl: true, nba: true, worldcup: true, olympic_mhockey: true, olympic_whockey: true };
 
-  var SUPPORTED_LEAGUES = ["mlb", "wbc", "nhl", "nfl", "nba", "olympic_mhockey", "olympic_whockey"];
+  var SUPPORTED_LEAGUES = ["mlb", "wbc", "nhl", "nfl", "nba", "worldcup", "olympic_mhockey", "olympic_whockey"];
   var MLB_MAX_GAMES_PER_PAGE = 8;
   var MLB_MAX_COLUMNS        = 2;
 
@@ -274,6 +274,7 @@
       highlightedTeams_nhl:             [],
       highlightedTeams_nfl:             [],
       highlightedTeams_nba:             [],
+      highlightedTeams_worldcup:        [],
       highlightedTeams_olympic_mhockey: [],
       highlightedTeams_olympic_whockey: [],
       highlightedTeams_oly_mhockey:     [],
@@ -293,6 +294,7 @@
       if (league === "nhl") return "NHL Scoreboard";
       if (league === "nfl") return "NFL Scoreboard";
       if (league === "nba") return "NBA Scoreboard";
+      if (league === "worldcup") return "World Cup Scoreboard";
       if (league === "olympic_mhockey") return "Men's Olympic Hockey Scoreboard";
       if (league === "olympic_whockey") return "Women's Olympic Hockey Scoreboard";
       return "Scoreboard";
@@ -614,6 +616,7 @@
       if (league === "nhl") return this.config.highlightedTeams_nhl;
       if (league === "nfl") return this.config.highlightedTeams_nfl;
       if (league === "nba") return this.config.highlightedTeams_nba;
+      if (league === "worldcup") return this.config.highlightedTeams_worldcup;
       if (league === "olympic_mhockey") {
         return this._pickFirstHighlightConfig([
           this.config.highlightedTeams_olympic_mhockey,
@@ -1484,7 +1487,7 @@
       if (league === "nhl") return this._createNhlGameCard(game);
       if (league === "nfl") return this._createNflGameCard(game);
       if (league === "nba") return this._createNbaGameCard(game);
-      if (league === "olympic_mhockey" || league === "olympic_whockey") return this._createNhlGameCard(game, league);
+      if (league === "olympic_mhockey" || league === "olympic_whockey" || league === "worldcup") return this._createNhlGameCard(game, league);
       return this._createMlbGameCard(game);
     },
 
@@ -2652,7 +2655,7 @@
           || "";
       } else if (league === "nhl") {
         abbr = team.teamAbbreviation || team.abbreviation || team.triCode || team.shortName || name;
-      } else if (league === "olympic_mhockey" || league === "olympic_whockey") {
+      } else if (league === "olympic_mhockey" || league === "olympic_whockey" || league === "worldcup") {
         var olympicName = String(
           team.shortDisplayName ||
           team.displayName ||
@@ -2772,6 +2775,8 @@
       if (league === "nhl") {
         path = "images/nhl/" + String(abbr || "").toUpperCase() + ".png";
       } else if (league === "olympic_mhockey") {
+        path = "images/oly/" + String(abbr || "").toUpperCase() + ".png";
+      } else if (league === "worldcup") {
         path = "images/oly/" + String(abbr || "").toUpperCase() + ".png";
       } else if (league === "olympic_whockey") {
         path = "images/oly/" + String(abbr || "").toUpperCase() + ".png";

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MMM-Scores
 
-A MagicMirror² module that cycles through MLB, NHL, NFL, NBA, and Olympic Ice Hockey scoreboards. Scores are fetched automatically from public APIs with sensible fallbacks.
+A MagicMirror² module that cycles through MLB, NHL, NFL, NBA, World Cup soccer, and Olympic Ice Hockey scoreboards. Scores are fetched automatically from public APIs with sensible fallbacks.
 
 ---
 
@@ -21,7 +21,7 @@ A MagicMirror² module that cycles through MLB, NHL, NFL, NBA, and Olympic Ice H
 ---
 
 ## Features
-- **Six-league scoreboards**: MLB (R/H/E linescore), NHL (goals & shots), NFL (quarter-by-quarter totals plus bye list), NBA (quarter/OT breakdown), Men's Olympic Hockey, and Women's Olympic Hockey.
+- **Eight-league scoreboards**: MLB (R/H/E linescore), WBC, NHL (goals & shots), NFL (quarter-by-quarter totals plus bye list), NBA (quarter/OT breakdown), World Cup soccer, Men's Olympic Hockey, and Women's Olympic Hockey.
 - **Automatic league rotation**: Show a single league, a custom sequence, or all supported leagues with timed page flips.
 - **Flexible layout**: Control columns, rows, or total games per page per league and scale everything with a single `layoutScale` value.
 - **Favorite team highlighting**: Per-league highlight lists add a subtle accent to matching teams on scoreboards.
@@ -54,7 +54,7 @@ Use this script to verify that every external API endpoint used by the helper is
 ```bash
 npm run test:api
 ```
-The command checks MLB, NHL (all fallback feeds), NFL, NBA, and both Olympic hockey ESPN endpoints, then exits non-zero if any connection fails.
+The command checks MLB, NHL (all fallback feeds), NFL, NBA, World Cup soccer, and both Olympic hockey ESPN endpoints, then exits non-zero if any connection fails.
 
 Use this Olympic-focused diagnostics script to check provider reachability and print normalized men's/women's Olympic games for a target date:
 ```bash
@@ -70,11 +70,12 @@ Add this entry to `config/config.js`:
   module: "MMM-Scores",
   position: "middle_center",
   config: {
-    league: "all",                 // "mlb", "nhl", "nfl", "nba", "olympic_mhockey", "olympic_whockey", array, or "all"
+    league: "all",                 // "mlb", "nhl", "nfl", "nba", "worldcup", "olympic_mhockey", "olympic_whockey", array, or "all"
     updateIntervalScores: 60 * 1000, // helper refresh frequency
     rotateIntervalScores: 15 * 1000, // front-end page flip interval
     layoutScale: 0.95,               // scale everything uniformly
     highlightedTeams_mlb: ["CUBS"],
+    highlightedTeams_worldcup: ["USA"],
     highlightedTeams_olympic_mhockey: ["USA"],
     highlightedTeams_oly_whockey: ["CAN"], // short alias also supported
     maxWidth: "720px"
@@ -90,29 +91,29 @@ Every option may be declared globally, as an object keyed by league (`{ mlb: val
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| `league` / `leagues` | `string \| string[]` | `"mlb"` | League(s) to display. Accepts `"mlb"`, `"nhl"`, `"nfl"`, `"nba"`, `"olympic_mhockey"`, `"olympic_whockey"`, or `"all"`. Arrays define the rotation order. |
+| `league` / `leagues` | `string \| string[]` | `"mlb"` | League(s) to display. Accepts `"mlb"`, `"wbc"`, `"nhl"`, `"nfl"`, `"nba"`, `"worldcup"`, `"olympic_mhockey"`, `"olympic_whockey"`, or `"all"`. Arrays define the rotation order. |
 | `updateIntervalScores` | `number` | `60000` | Milliseconds between helper fetches. Minimum enforced interval is 10 seconds. |
 | `rotateIntervalScores` | `number` | `15000` | Milliseconds between scoreboard page rotations. |
 | `timeZone` | `string` | `"America/Chicago"` | Time zone used to decide the scoreboard date (all leagues use previous day before 09:30 local, Olympics use previous day before 03:00 local). |
 | `providerCacheMs` | `number` | `20000` | Per-provider/per-date Olympic provider cache TTL in milliseconds (minimum 15000). |
-| `scoreboardColumns` | `number` | auto | Columns per page. Defaults to 2 for MLB (capped at 2) and 4 for NHL/NFL/NBA/Olympic hockey. |
+| `scoreboardColumns` | `number` | auto | Columns per page. Defaults to 2 for MLB (capped at 2) and 4 for NHL/NFL/NBA/World Cup/Olympic hockey. |
 | `gamesPerColumn` (`scoreboardRows`) | `number` | auto | Games stacked in each column (4 for all leagues unless overridden). |
 | `gamesPerPage` | `number` | derived | Override the total games per page; rows adjust automatically per league. |
 | `layoutScale` | `number` | `1` | Scales the entire module (clamped between 0.6 and 1.4). |
-| `highlightedTeams_mlb` | `string \| string[]` | `[]` | Team abbreviations to highlight. Also available as `_nhl`, `_nfl`, `_nba`, `_olympic_mhockey`/`_oly_mhockey`, `_olympic_whockey`/`_oly_whockey`. |
+| `highlightedTeams_mlb` | `string \| string[]` | `[]` | Team abbreviations to highlight. Also available as `_nhl`, `_nfl`, `_nba`, `_worldcup`, `_olympic_mhockey`/`_oly_mhockey`, `_olympic_whockey`/`_oly_whockey`. |
 | `showTitle` | `boolean` | `true` | Toggles the module header (`MLB Scoreboard`, etc.). |
 | `useTimesSquareFont` | `boolean` | `true` | Applies the Times Square font to scoreboard cards. |
 | `maxWidth` | `string \| number` | `"800px"` | Caps the module width and header alignment. Numbers are treated as pixels. |
 
 ### Layout controls
-- **Per-league overrides**: Append the league suffix (`_nhl`, `_nfl`, `_nba`, `_mlb`, `_olympic_mhockey`, `_olympic_whockey`) to `scoreboardColumns`, `gamesPerColumn`, or `gamesPerPage` to change a single league's layout.
+- **Per-league overrides**: Append the league suffix (`_nhl`, `_nfl`, `_nba`, `_mlb`, `_worldcup`, `_olympic_mhockey`, `_olympic_whockey`) to `scoreboardColumns`, `gamesPerColumn`, or `gamesPerPage` to change a single league's layout.
 - **Object form**: For `layoutScale` or highlight lists, you can pass an object with `default` and per-league keys.
 
 ### League rotation
 The module keeps an internal rotation list derived from `league`/`leagues`. It fetches games for every configured league on each helper poll and flips the front-end page every `rotateIntervalScores` milliseconds.
 
 ### Highlighting
-Highlight any number of teams per league using the appropriate `_mlb`, `_nhl`, `_nfl`, `_nba`, `_olympic_mhockey` (or `_oly_mhockey`), or `_olympic_whockey` (or `_oly_whockey`) suffix. Highlights apply to scoreboards.
+Highlight any number of teams per league using the appropriate `_mlb`, `_nhl`, `_nfl`, `_nba`, `_worldcup`, `_olympic_mhockey` (or `_oly_mhockey`), or `_olympic_whockey` (or `_oly_whockey`) suffix. Highlights apply to scoreboards.
 
 Olympic hockey country mapping uses IOC-style 3-letter codes (`CAN`, `USA`, `FIN`, `SWE`, `GER`, `SUI`, `CZE`, `SVK`, `LAT`, `DEN`, `FRA`, `ITA`, `JPN`).
 
@@ -136,9 +137,9 @@ MMM-Scores/
    ├─ nba/
    │  └─ ATL.png (etc.)
    └─ oly/
-      └─ USA.png (Olympic country flags, uppercase IOC code)
+      └─ USA.png (Olympic/World Cup country flags, uppercase country code)
 ```
-- **Logos**: Place transparent PNG logos named with the abbreviations used in-game data (`CUBS.png`, `NYR.png`, `kc.png`, `CHI.png`, etc.). The module falls back to text when a logo is missing. Olympic men's/women's hockey both read from `images/oly/<CODE>.png` (for example `CAN.png`, `USA.png`, `SWE.png`).
+- **Logos**: Place transparent PNG logos named with the abbreviations used in-game data (`CUBS.png`, `NYR.png`, `kc.png`, `CHI.png`, etc.). The module falls back to text when a logo is missing. Olympic men's/women's hockey and World Cup soccer read from `images/oly/<CODE>.png` (for example `CAN.png`, `USA.png`, `SWE.png`).
 - **Font**: Drop `fonts/TimesSquare-m105.ttf` into `fonts/`. The CSS registers it with `@font-face`.
 - **Styling tweaks**: Override CSS variables in `MMM-Scores.css` or globally (e.g., `css/custom.css`). Useful variables include `--scoreboard-card-width-base`, `--scoreboard-team-font-base`, `--scoreboard-value-font-base`, `--scoreboard-gap-base`, and `--matrix-gap-base`.
 
@@ -159,6 +160,7 @@ Scoreboard data comes from league-specific feeds with fallbacks where needed.
 - **MLB scores**: `https://statsapi.mlb.com/api/v1/schedule/games?sportId=1&hydrate=linescore` (date based on `timeZone`).
 - **NHL scores**: Prefers `statsapi.web.nhl.com` endpoints with automatic fallbacks to the public scoreboard and REST feeds; the date adjusts for early-morning previous-day fetches.
 - **NBA scores**: `https://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard` for the selected date.
+- **World Cup soccer scores**: `https://site.api.espn.com/apis/site/v2/sports/soccer/fifa.world/scoreboard` for the selected date.
 - **NFL scores**: Weekly schedules from `https://site.api.espn.com/apis/site/v2/sports/football/nfl/scoreboard?dates=<YYYYMMDD>` aggregated across the current week; includes bye-week teams.
 - **Men's Olympic hockey scores**: Primary `https://site.api.espn.com/apis/site/v2/sports/hockey/mens-olympics/scoreboard?dates=<YYYYMMDD>` with resilient provider-chain hooks (`olympics.com`, IIHF, TheSportsDB, Wikipedia/Wikidata finals) and last-good-data fallback.
 - **Women's Olympic hockey scores**: Primary `https://site.api.espn.com/apis/site/v2/sports/hockey/womens-olympics/scoreboard?dates=<YYYYMMDD>` with the same provider-chain/fallback architecture.

--- a/node_helper.js
+++ b/node_helper.js
@@ -61,7 +61,7 @@ const fetch = (typeof global.fetch === "function")
   ? global.fetch.bind(global)
   : createHttpFetchFallback();
 
-const SUPPORTED_LEAGUES = ["mlb", "wbc", "nhl", "nfl", "nba", "olympic_mhockey", "olympic_whockey"];
+const SUPPORTED_LEAGUES = ["mlb", "wbc", "nhl", "nfl", "nba", "worldcup", "olympic_mhockey", "olympic_whockey"];
 const MLB_SCOREBOARD_SPORT_IDS = [1, 51]; // MLB + World Baseball Classic
 const MLB_INTERNATIONAL_WBC_TEAM_IDS = new Set([
   776, // Brazil
@@ -165,6 +165,8 @@ module.exports = NodeHelper.create({
           await this._fetchNflGames();
         } else if (league === "nba") {
           await this._fetchNbaGames();
+        } else if (league === "worldcup") {
+          await this._fetchWorldCupGames();
         } else {
           await this._fetchMlbGames();
         }
@@ -1756,6 +1758,46 @@ module.exports = NodeHelper.create({
     }
 
     return collected;
+  },
+
+  async _fetchWorldCupGames() {
+    try {
+      const { dateIso, dateCompact } = this._getTargetDate();
+      const url = `https://site.api.espn.com/apis/site/v2/sports/soccer/fifa.world/scoreboard?dates=${dateCompact}`;
+      const res = await fetch(url);
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status} ${res.statusText}`);
+      }
+
+      const json = await res.json();
+      const events = this._collectEspnScoreboardEvents(json);
+
+      events.sort((a, b) => {
+        const dateA = this._firstDate(
+          a && a.date,
+          a && a.startDate,
+          a && a.startTimeUTC,
+          a && a.competitions && a.competitions[0] && (a.competitions[0].date || a.competitions[0].startDate || a.competitions[0].startTimeUTC)
+        );
+        const dateB = this._firstDate(
+          b && b.date,
+          b && b.startDate,
+          b && b.startTimeUTC,
+          b && b.competitions && b.competitions[0] && (b.competitions[0].date || b.competitions[0].startDate || b.competitions[0].startTimeUTC)
+        );
+
+        if (dateA && dateB) return dateA - dateB;
+        if (dateA) return -1;
+        if (dateB) return 1;
+        return 0;
+      });
+
+      console.log(`⚽ Sending ${events.length} World Cup games for ${dateIso} to front-end.`);
+      this._notifyGames("worldcup", events);
+    } catch (e) {
+      console.error("🚨 World Cup fetchGames failed:", e);
+      this._notifyGames("worldcup", []);
+    }
   },
 
   async _fetchNflGames() {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "MMM-Scores",
   "version": "1.0.0",
-  "description": "MagicMirror module to display today's MLB, NHL, NFL, and NBA scoreboards",
+  "description": "MagicMirror module to display today's MLB, NHL, NFL, NBA, World Cup, and Olympic scoreboards",
   "main": "MMM-Scores.js",
   "scripts": {
     "test:api": "node scripts/test-api-connections.js",

--- a/scripts/test-api-connections.js
+++ b/scripts/test-api-connections.js
@@ -107,6 +107,10 @@ async function main() {
       url: "https://site.api.espn.com/apis/site/v2/sports/football/nfl/scoreboard"
     },
     {
+      name: "World Cup ESPN scoreboard",
+      url: `https://site.api.espn.com/apis/site/v2/sports/soccer/fifa.world/scoreboard?dates=${dateCompact}`
+    },
+    {
       name: "Olympic men's hockey ESPN scoreboard",
       url: `https://site.api.espn.com/apis/site/v2/sports/hockey/mens-olympics/scoreboard?dates=${dateCompact}`
     },


### PR DESCRIPTION
### Motivation

- Add World Cup (FIFA) scoreboard support so the module can display international soccer tournament games alongside existing leagues.

### Description

- Add `worldcup` to the supported leagues in both the helper (`node_helper.js`) and front-end (`MMM-Scores.js`) rotation/config handling and layout logic. 
- Implement `_fetchWorldCupGames()` in the helper to pull ESPN’s FIFA World Cup scoreboard (`site.api.espn.com/apis/site/v2/sports/soccer/fifa.world/scoreboard`) and wire it into the helper fetch loop with `this._notifyGames("worldcup", events)`. 
- Reuse front-end rendering paths by treating World Cup events like the Olympic country-based leagues for abbreviation/flag lookup and compact/pro scoreboard layouts, add a `World Cup Scoreboard` header and per-league highlight config `highlightedTeams_worldcup`. 
- Update documentation (`README.md`), API connectivity probe (`scripts/test-api-connections.js`) to include the World Cup endpoint, and `package.json` description.

### Testing

- Ran static checks with `node --check node_helper.js`, `node --check MMM-Scores.js`, and `node --check scripts/test-api-connections.js`, all of which succeeded. 
- Executed the connectivity probe via `npm run test:api` (which runs `scripts/test-api-connections.js`), and it reported network/DNS failures for all external endpoints (environment is network-limited), so API calls could not be validated here. 
- No unit tests were added; behavior relies on the existing ESPN scoreboard normalization and the module’s existing rendering/tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ef3428b5c8322b9a263afd377b15a)