### PR TITLE
Fix World Cup scoreboard compact layout

### DIFF
--- a/MMM-Scores.css
+++ b/MMM-Scores.css
@@ -102,6 +102,7 @@
 
 .games-matrix.league-nfl,
 .games-matrix.league-nhl,
+.games-matrix.league-worldcup,
 .games-matrix.league-olympic_mhockey,
 .games-matrix.league-olympic_whockey,
 .games-matrix.league-nba {
@@ -227,6 +228,7 @@
 
 .scoreboard-card.league-nfl,
 .scoreboard-card.league-nhl,
+.scoreboard-card.league-worldcup,
 .scoreboard-card.league-olympic_mhockey,
 .scoreboard-card.league-olympic_whockey,
 .scoreboard-card.league-nba {
@@ -361,6 +363,7 @@
 }
 
 .scoreboard-card.league-nhl .scoreboard-team,
+.scoreboard-card.league-worldcup .scoreboard-team,
 .scoreboard-card.league-olympic_mhockey .scoreboard-team,
 .scoreboard-card.league-olympic_whockey .scoreboard-team {
   display: grid;
@@ -421,6 +424,7 @@
 }
 
 .scoreboard-card.league-nhl .scoreboard-team-logo[src*="/WSH.png"],
+.scoreboard-card.league-worldcup .scoreboard-team-logo[src*="/WSH.png"],
 .scoreboard-card.league-olympic_mhockey .scoreboard-team-logo[src*="/WSH.png"],
 .scoreboard-card.league-olympic_whockey .scoreboard-team-logo[src*="/WSH.png"] {
   height: calc(var(--scoreboard-team-font) * 0.9);
@@ -451,6 +455,7 @@
 }
 
 .scoreboard-card.league-nhl .scoreboard-team-abbr,
+.scoreboard-card.league-worldcup .scoreboard-team-abbr,
 .scoreboard-card.league-olympic_mhockey .scoreboard-team-abbr,
 .scoreboard-card.league-olympic_whockey .scoreboard-team-abbr {
   justify-self: start;


### PR DESCRIPTION
### Motivation
- World Cup scoreboards were using the regular (wide) card/grid sizing and row layout which caused content to overflow and appear misaligned in compact multi-column displays. 
- The module already applies a compact layout for several international/compact leagues (NHL, NFL, NBA, Olympic hockey) but omitted `worldcup`, so World Cup cards did not inherit the narrower sizing and abbr/logo grid rules. 
- This change ensures World Cup scoreboards match the compact layout that other international leagues use for consistent visual alignment.

### Description
- Updated `MMM-Scores.css` to add `.games-matrix.league-worldcup` to the compact matrix selector so World Cup pages use the compact column width. 
- Added `.scoreboard-card.league-worldcup` to the compact card selector so World Cup cards inherit the compact card width variable. 
- Included `.scoreboard-card.league-worldcup` in the team/logo/abbreviation grid and specific logo/abbr selectors so flags, logos, and abbreviations align like other compact international scoreboards. 
- All changes are confined to `MMM-Scores.css` and only add `league-worldcup` to existing selector groups.

### Testing
- Ran `node --check MMM-Scores.js` which completed successfully. 
- Ran a quick selector presence check with `node -e "..."` to assert `.games-matrix.league-worldcup` and `.scoreboard-card.league-worldcup` exist in `MMM-Scores.css`, which succeeded. 
- Ran `git diff --check` with no style errors reported. 
- Ran `npm run test:api` which exercised the API connectivity script but failed due to the execution environment being unable to reach external network/DNS (all API checks reported network errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3003e2092083229c576c8211518afc)