### PR TITLE
Exclude international/WBC games from MLB scoreboard

### DIFF
--- a/MMM-Scores.js
+++ b/MMM-Scores.js
@@ -511,17 +511,7 @@
 
     _expandMlbLeagueFamily: function (leagues) {
       if (!Array.isArray(leagues) || leagues.length === 0) return [];
-
-      var expanded = [];
-      for (var i = 0; i < leagues.length; i++) {
-        var league = leagues[i];
-        if (expanded.indexOf(league) === -1) expanded.push(league);
-        if (league === "mlb" && expanded.indexOf("wbc") === -1) {
-          expanded.push("wbc");
-        }
-      }
-
-      return expanded;
+      return leagues.slice();
     },
 
     _rebuildLeagueRotation: function (preferredLeague) {

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Example:
 ## Data Sources
 Scoreboard data comes from league-specific feeds with fallbacks where needed.
 
-- **MLB scores**: `https://statsapi.mlb.com/api/v1/schedule/games?sportId=1&hydrate=linescore` (date based on `timeZone`).
+- **MLB scores**: `https://statsapi.mlb.com/api/v1/schedule/games?sportId=1&hydrate=linescore` (date based on `timeZone`), filtered to MLB club-vs-club games only. International/WBC matchups are kept off the MLB scoreboard and only appear when `wbc` is explicitly configured.
 - **NHL scores**: Prefers `statsapi.web.nhl.com` endpoints with automatic fallbacks to the public scoreboard and REST feeds; the date adjusts for early-morning previous-day fetches.
 - **NBA scores**: `https://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard` for the selected date.
 - **World Cup soccer scores**: `https://site.api.espn.com/apis/site/v2/sports/soccer/fifa.world/scoreboard` for the selected date; live cards show `1H`, `2H`, `ET`, match minutes, stoppage time such as `45'+2'`, and shootout superscripts when provided by the feed.

--- a/node_helper.js
+++ b/node_helper.js
@@ -62,7 +62,7 @@ const fetch = (typeof global.fetch === "function")
   : createHttpFetchFallback();
 
 const SUPPORTED_LEAGUES = ["mlb", "wbc", "nhl", "nfl", "nba", "worldcup", "olympic_mhockey", "olympic_whockey"];
-const MLB_SCOREBOARD_SPORT_IDS = [1, 51]; // MLB + World Baseball Classic
+const MLB_SCOREBOARD_SPORT_IDS = [1, 51]; // MLB plus explicit international/WBC feeds, split before display
 const MLB_INTERNATIONAL_WBC_TEAM_IDS = new Set([
   776, // Brazil
   784, // Canada
@@ -222,15 +222,15 @@ module.exports = NodeHelper.create({
 
     for (let i = 0; i < games.length; i += 1) {
       const game = games[i];
-      if (this._isInternationalWbcGame(game)) wbc.push(game);
+      if (this._isInternationalMlbGame(game)) wbc.push(game);
       else mlb.push(game);
     }
 
     return { mlb, wbc };
   },
 
-  _isInternationalWbcGame(game) {
-    return this._countInternationalWbcTeams(game) >= 2;
+  _isInternationalMlbGame(game) {
+    return this._countInternationalWbcTeams(game) > 0;
   },
 
   async _fetchMlbGamesBySport(dateIso, sportId) {
@@ -2181,15 +2181,7 @@ module.exports = NodeHelper.create({
 
   _expandMlbLeagueFamily(leagues) {
     if (!Array.isArray(leagues) || leagues.length === 0) return [];
-
-    const expanded = [];
-    for (let i = 0; i < leagues.length; i += 1) {
-      const league = leagues[i];
-      if (!expanded.includes(league)) expanded.push(league);
-      if (league === "mlb" && !expanded.includes("wbc")) expanded.push("wbc");
-    }
-
-    return expanded;
+    return leagues.slice();
   },
 
   _todayIsoInTimeZone() {


### PR DESCRIPTION
### Motivation
- Ensure the MLB scoreboard only shows MLB club-vs-club games and not international/WBC matchups.
- Prevent `wbc` from being silently added when `league: "mlb"` is configured so WBC games appear only when explicitly requested.
- Update docs to reflect the new behavior so users know to enable `wbc` to see international matchups.

### Description
- Changed MLB game splitting in `node_helper.js` so `_splitMlbAndWbcGames` uses a new `_isInternationalMlbGame` predicate that excludes any game with one or more international/WBC teams from the MLB bucket (moves them to `wbc`).
- Renamed/repurposed the international checker to `_isInternationalMlbGame` and updated its logic to `this._countInternationalWbcTeams(game) > 0` so any international involvement is treated as non-MLB.
- Stopped automatically expanding the configured `mlb` league to include `wbc` by simplifying `_expandMlbLeagueFamily` in both `node_helper.js` and `MMM-Scores.js` to return `leagues.slice()` instead of injecting `wbc`.
- Updated `README.md` to document that MLB scores are filtered to club-vs-club games and that international/WBC matchups require explicit `wbc` configuration.

### Testing
- Ran syntax/type checks with `node --check node_helper.js`, which succeeded.
- Ran syntax/type checks with `node --check MMM-Scores.js`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42daba691c83229471c4bbe3fbb112)