### PR TITLE
Show previous-day finals before scoreboard cutoff and add schedule page

### DIFF
--- a/MMM-Scores.js
+++ b/MMM-Scores.js
@@ -317,6 +317,7 @@
       this.loadedLeagues   = {};
       this.extrasByLeague  = {};
       this.currentExtras   = null;
+      this.scheduleGamesByLeague = {};
 
       this._leagueRotation    = this._resolveConfiguredLeagues();
       if (!Array.isArray(this._leagueRotation) || this._leagueRotation.length === 0) {
@@ -594,7 +595,12 @@
         : 0;
       this._scoreboardPageCount = scoreboardPages;
 
-      var totalPages = scoreboardPages;
+      var scheduleGames = (this.scheduleGamesByLeague && Array.isArray(this.scheduleGamesByLeague[league]))
+        ? this.scheduleGamesByLeague[league]
+        : [];
+      var schedulePages = scheduleGames.length > 0 ? 1 : 0;
+
+      var totalPages = scoreboardPages + schedulePages;
       if (totalPages === 0) totalPages = 1;
 
       this.totalGamePages = totalPages;
@@ -1270,6 +1276,13 @@
           if (!this.loadedLeagues) this.loadedLeagues = {};
           this.loadedLeagues[league] = true;
 
+          if (!this.scheduleGamesByLeague) this.scheduleGamesByLeague = {};
+          if (extras && Array.isArray(extras.scheduleGames) && extras.scheduleGames.length > 0) {
+            this.scheduleGamesByLeague[league] = extras.scheduleGames;
+          } else if (Object.prototype.hasOwnProperty.call(this.scheduleGamesByLeague, league)) {
+            delete this.scheduleGamesByLeague[league];
+          }
+
           if (!this.extrasByLeague) this.extrasByLeague = {};
           if (extras && Object.keys(extras).length > 0) {
             this.extrasByLeague[league] = extras;
@@ -1321,7 +1334,11 @@
         this._setModuleContentWidth(null);
         return this._noData("Loading games...");
       }
-      if (this.games.length === 0) {
+      var activeLeagueForData = this._getLeague();
+      var activeScheduleGames = (this.scheduleGamesByLeague && Array.isArray(this.scheduleGamesByLeague[activeLeagueForData]))
+        ? this.scheduleGamesByLeague[activeLeagueForData]
+        : [];
+      if (this.games.length === 0 && activeScheduleGames.length === 0) {
         this._setModuleContentWidth(null);
         return this._noData("No games to display.");
       }
@@ -1369,9 +1386,27 @@
       var scoreboardPages = this._scoreboardPageCount || 0;
       var scoreboardRendered = false;
 
+      var scheduleGamesForLeague = (this.scheduleGamesByLeague && Array.isArray(this.scheduleGamesByLeague[activeLeague]))
+        ? this.scheduleGamesByLeague[activeLeague]
+        : [];
+      var pageGames = null;
+      var isSchedulePage = false;
+
       if (scoreboardPages > 0 && this.currentScreen < scoreboardPages) {
         var start = this.currentScreen * this._gamesPerPage;
-        var games = this.games.slice(start, start + this._gamesPerPage);
+        pageGames = this.games.slice(start, start + this._gamesPerPage);
+      } else if (scheduleGamesForLeague.length > 0 && this.currentScreen === scoreboardPages) {
+        pageGames = scheduleGamesForLeague.slice(0, this._gamesPerPage);
+        isSchedulePage = true;
+      }
+
+      if (pageGames && pageGames.length > 0) {
+        if (isSchedulePage) {
+          var scheduleTitle = document.createElement("div");
+          scheduleTitle.className = "small dimmed";
+          scheduleTitle.innerText = "Today's Schedule";
+          container.appendChild(scheduleTitle);
+        }
 
         var matrix = document.createElement("div");
         matrix.className = "games-matrix";
@@ -1382,13 +1417,13 @@
         var orderedGames = new Array(totalSlots);
         var isRightPlacement = this._shouldUseRightPlacement();
 
-        var limit = games.length < totalSlots ? games.length : totalSlots;
+        var limit = pageGames.length < totalSlots ? pageGames.length : totalSlots;
         for (var gi = 0; gi < limit; gi++) {
           var columnIndex = Math.floor(gi / this._scoreboardRows);
           if (isRightPlacement) columnIndex = (this._scoreboardColumns - 1) - columnIndex;
           var rowIndex = gi % this._scoreboardRows;
           var slotIndex = rowIndex * this._scoreboardColumns + columnIndex;
-          orderedGames[slotIndex] = games[gi];
+          orderedGames[slotIndex] = pageGames[gi];
         }
 
         for (var r = 0; r < this._scoreboardRows; r++) {
@@ -1420,7 +1455,7 @@
         }
 
         container.appendChild(matrix);
-        scoreboardRendered = true;
+        scoreboardRendered = !isSchedulePage;
       }
 
       if (scoreboardRendered && activeLeague === "nfl") {

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Every option may be declared globally, as an object keyed by league (`{ mlb: val
 | `league` / `leagues` | `string \| string[]` | `"mlb"` | League(s) to display. Accepts `"mlb"`, `"wbc"`, `"nhl"`, `"nfl"`, `"nba"`, `"worldcup"`, `"olympic_mhockey"`, `"olympic_whockey"`, or `"all"`. Arrays define the rotation order. |
 | `updateIntervalScores` | `number` | `60000` | Milliseconds between helper fetches. Minimum enforced interval is 10 seconds. |
 | `rotateIntervalScores` | `number` | `15000` | Milliseconds between scoreboard page rotations. |
-| `timeZone` | `string` | `"America/Chicago"` | Time zone used to decide the scoreboard date (all leagues use previous day before 09:30 local, Olympics use previous day before 03:00 local). |
+| `timeZone` | `string` | `"America/Chicago"` | Time zone used to decide the scoreboard date. Before the configured daily update cutoff (09:30 local for most leagues, 03:00 for Olympic hockey), scoreboards show previous-day final scores and then rotate to a current-day schedule screen; after the cutoff they show the current day's scoreboard. |
 | `providerCacheMs` | `number` | `20000` | Per-provider/per-date Olympic provider cache TTL in milliseconds (minimum 15000). |
 | `scoreboardColumns` | `number` | auto | Columns per page. Defaults to 2 for MLB (capped at 2) and 4 for NHL/NFL/NBA/World Cup/Olympic hockey. |
 | `gamesPerColumn` (`scoreboardRows`) | `number` | auto | Games stacked in each column (4 for all leagues unless overridden). |

--- a/node_helper.js
+++ b/node_helper.js
@@ -184,8 +184,10 @@ module.exports = NodeHelper.create({
 
   async _fetchMlbGames() {
     try {
-      const { dateIso } = this._getTargetDate();
+      const context = this._getScoreboardDateContext();
+      const dateIso = context.scoreboardDateIso;
       const gamesByPk = new Map();
+      const scheduleByPk = new Map();
 
       for (const sportId of MLB_SCOREBOARD_SPORT_IDS) {
         const games = await this._fetchMlbGamesBySport(dateIso, sportId);
@@ -194,6 +196,15 @@ module.exports = NodeHelper.create({
           const gamePk = Number(game && game.gamePk);
           if (Number.isFinite(gamePk)) {
             gamesByPk.set(gamePk, game);
+          }
+        }
+
+        if (context.beforeUpdateCutoff) {
+          const scheduleGames = await this._fetchMlbGamesBySport(context.todayIso, sportId);
+          for (let i = 0; i < scheduleGames.length; i += 1) {
+            const game = scheduleGames[i];
+            const gamePk = Number(game && game.gamePk);
+            if (Number.isFinite(gamePk)) scheduleByPk.set(gamePk, game);
           }
         }
       }
@@ -207,11 +218,19 @@ module.exports = NodeHelper.create({
         return aDate - bDate;
       });
 
-      const separatedGames = this._splitMlbAndWbcGames(games);
+      const displayGames = context.beforeUpdateCutoff ? this._finalGamesOnly(games) : games;
+      const separatedGames = this._splitMlbAndWbcGames(displayGames);
+      const separatedSchedule = context.beforeUpdateCutoff
+        ? this._splitMlbAndWbcGames(Array.from(scheduleByPk.values()).sort((a, b) => {
+          const aDate = Date.parse((a && a.gameDate) || "") || 0;
+          const bDate = Date.parse((b && b.gameDate) || "") || 0;
+          return aDate - bDate;
+        }))
+        : { mlb: [], wbc: [] };
 
       console.log(`⚾️ Sending ${separatedGames.mlb.length} MLB games to front-end.`);
-      this._notifyGames("mlb", separatedGames.mlb);
-      this._notifyGames("wbc", separatedGames.wbc);
+      this._notifyGames("mlb", separatedGames.mlb, { scheduleGames: separatedSchedule.mlb, showingPreviousFinals: context.beforeUpdateCutoff });
+      this._notifyGames("wbc", separatedGames.wbc, { scheduleGames: separatedSchedule.wbc, showingPreviousFinals: context.beforeUpdateCutoff });
     } catch (e) {
       console.error("🚨 MLB fetchGames failed:", e);
       this._notifyGames("mlb", []);
@@ -296,9 +315,17 @@ module.exports = NodeHelper.create({
   },
 
   async _fetchNhlGames() {
-    const { dateIso } = this._getTargetDate();
-    const scoreboardDateIso = this._getNhlScoreboardDate();
-    const targetDate = scoreboardDateIso || dateIso;
+    const context = this._getScoreboardDateContext();
+    const dateIso = context.dateIso;
+    const targetDate = context.scoreboardDateIso;
+    let scheduleGames = [];
+    if (context.beforeUpdateCutoff) {
+      try {
+        scheduleGames = await this._fetchNhlScoreboardGames(context.todayIso);
+      } catch (scheduleError) {
+        console.warn(`⚠️ NHL current-day schedule fetch failed for ${context.todayIso}:`, scheduleError.message || scheduleError);
+      }
+    }
 
     let delivered = false;
     let sent = false;
@@ -316,7 +343,7 @@ module.exports = NodeHelper.create({
         const games = Array.isArray(statsGames) ? statsGames : [];
         const count = games.length;
 
-        this._notifyGames("nhl", games);
+        this._notifyGames("nhl", context.beforeUpdateCutoff ? this._finalGamesOnly(games) : games, { scheduleGames, showingPreviousFinals: context.beforeUpdateCutoff });
         sent = true;
 
         if (count > 0) {
@@ -339,7 +366,7 @@ module.exports = NodeHelper.create({
         const games = Array.isArray(scoreboardGames) ? scoreboardGames : [];
         const count = games.length;
 
-        this._notifyGames("nhl", games);
+        this._notifyGames("nhl", context.beforeUpdateCutoff ? this._finalGamesOnly(games) : games, { scheduleGames, showingPreviousFinals: context.beforeUpdateCutoff });
         sent = true;
 
         if (count > 0) {
@@ -359,7 +386,7 @@ module.exports = NodeHelper.create({
         const restGames = await this._fetchNhlStatsRestGames(targetDate);
         if (restGames.length > 0) {
           console.log(`🏒 Sending ${restGames.length} NHL games to front-end (stats REST fallback).`);
-          this._notifyGames("nhl", restGames);
+          this._notifyGames("nhl", context.beforeUpdateCutoff ? this._finalGamesOnly(restGames) : restGames, { scheduleGames, showingPreviousFinals: context.beforeUpdateCutoff });
           delivered = true;
           sent = true;
         } else {
@@ -1213,8 +1240,18 @@ module.exports = NodeHelper.create({
       ];
 
     try {
-      const { dateIso, dateCompact } = this._getTargetDate({ previousDayCutoffMinutes: 3 * 60 });
+      const context = this._getScoreboardDateContext({ previousDayCutoffMinutes: 3 * 60 });
+      const { dateIso, dateCompact } = context;
       let normalizedGames = [];
+      let scheduleGames = [];
+      if (context.beforeUpdateCutoff) {
+        try {
+          const scheduleCandidate = await providerPlans[0].fetcher(context.todayIso, context.todayCompact);
+          scheduleGames = this._normalizedGamesToLegacyEvents(Array.isArray(scheduleCandidate) ? scheduleCandidate : []);
+        } catch (scheduleError) {
+          console.warn(`⚠️ ${leagueKey} current-day schedule fetch failed for ${context.todayIso}:`, scheduleError.message || scheduleError);
+        }
+      }
       let providerUsed = "none";
 
       for (let i = 0; i < providerPlans.length; i += 1) {
@@ -1258,8 +1295,11 @@ module.exports = NodeHelper.create({
       }
 
       const events = this._normalizedGamesToLegacyEvents(normalizedGames);
-      console.log(`🥅 Sending ${events.length} ${leagueKey} games for ${dateIso} to front-end via ${providerUsed}.`);
-      this._notifyGames(leagueKey, events, {
+      const displayEvents = context.beforeUpdateCutoff ? this._finalGamesOnly(events) : events;
+      console.log(`🥅 Sending ${displayEvents.length} ${leagueKey} games for ${dateIso} to front-end via ${providerUsed}.`);
+      this._notifyGames(leagueKey, displayEvents, {
+        scheduleGames,
+        showingPreviousFinals: context.beforeUpdateCutoff,
         olympicDiagnostics: {
           providerUsed,
           fetchedAtUTC: new Date().toISOString(),
@@ -1699,7 +1739,8 @@ module.exports = NodeHelper.create({
 
   async _fetchNbaGames() {
     try {
-      const { dateIso, dateCompact } = this._getTargetDate();
+      const context = this._getScoreboardDateContext();
+      const { dateIso, dateCompact } = context;
       const url = `https://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard?dates=${dateCompact}`;
       const res = await fetch(url);
       if (!res.ok) {
@@ -1728,8 +1769,15 @@ module.exports = NodeHelper.create({
         return 0;
       });
 
-      console.log(`🏀 Sending ${events.length} NBA games for ${dateIso} to front-end.`);
-      this._notifyGames("nba", events);
+      let scheduleGames = [];
+      if (context.beforeUpdateCutoff) {
+        const scheduleUrl = `https://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard?dates=${context.todayCompact}`;
+        const scheduleRes = await fetch(scheduleUrl);
+        if (scheduleRes.ok) scheduleGames = this._collectEspnScoreboardEvents(await scheduleRes.json());
+      }
+      const displayEvents = context.beforeUpdateCutoff ? this._finalGamesOnly(events) : events;
+      console.log(`🏀 Sending ${displayEvents.length} NBA games for ${dateIso} to front-end.`);
+      this._notifyGames("nba", displayEvents, { scheduleGames, showingPreviousFinals: context.beforeUpdateCutoff });
     } catch (e) {
       console.error("🚨 NBA fetchGames failed:", e);
       this._notifyGames("nba", []);
@@ -1767,7 +1815,8 @@ module.exports = NodeHelper.create({
 
   async _fetchWorldCupGames() {
     try {
-      const { dateIso, dateCompact } = this._getTargetDate();
+      const context = this._getScoreboardDateContext();
+      const { dateIso, dateCompact } = context;
       const url = `https://site.api.espn.com/apis/site/v2/sports/soccer/fifa.world/scoreboard?dates=${dateCompact}`;
       const res = await fetch(url);
       if (!res.ok) {
@@ -1797,8 +1846,15 @@ module.exports = NodeHelper.create({
         return 0;
       });
 
-      console.log(`⚽ Sending ${events.length} World Cup games for ${dateIso} to front-end.`);
-      this._notifyGames("worldcup", events);
+      let scheduleGames = [];
+      if (context.beforeUpdateCutoff) {
+        const scheduleUrl = `https://site.api.espn.com/apis/site/v2/sports/soccer/fifa.world/scoreboard?dates=${context.todayCompact}`;
+        const scheduleRes = await fetch(scheduleUrl);
+        if (scheduleRes.ok) scheduleGames = this._collectEspnScoreboardEvents(await scheduleRes.json());
+      }
+      const displayEvents = context.beforeUpdateCutoff ? this._finalGamesOnly(events) : events;
+      console.log(`⚽ Sending ${displayEvents.length} World Cup games for ${dateIso} to front-end.`);
+      this._notifyGames("worldcup", displayEvents, { scheduleGames, showingPreviousFinals: context.beforeUpdateCutoff });
     } catch (e) {
       console.error("🚨 World Cup fetchGames failed:", e);
       this._notifyGames("worldcup", []);
@@ -1807,6 +1863,20 @@ module.exports = NodeHelper.create({
 
   async _fetchNflGames() {
     try {
+      const context = this._getScoreboardDateContext();
+      if (context.beforeUpdateCutoff) {
+        const previousResults = await this._fetchNflWeekGames([context.previousDateIso]);
+        const todayResults = await this._fetchNflWeekGames([context.todayIso]);
+        const games = this._finalGamesOnly(previousResults.games);
+        console.log(`🏈 Sending ${games.length} NFL final games for ${context.previousDateIso} plus ${todayResults.games.length} scheduled games for ${context.todayIso}.`);
+        this._notifyGames("nfl", games, {
+          teamsOnBye: previousResults.byes,
+          scheduleGames: todayResults.games,
+          showingPreviousFinals: true
+        });
+        return;
+      }
+
       const weekRange = this._getNflWeekDateRange();
       let results = await this._fetchNflWeekGames(weekRange.dateIsos);
 
@@ -2215,6 +2285,14 @@ module.exports = NodeHelper.create({
   },
 
   _getTargetDate(options) {
+    const context = this._getScoreboardDateContext(options);
+    return {
+      dateIso: context.scoreboardDateIso,
+      dateCompact: context.scoreboardDateIso.replace(/-/g, "")
+    };
+  },
+
+  _getScoreboardDateContext(options) {
     const opts = options && typeof options === "object" ? options : {};
     const usePreviousDayEarly = opts.usePreviousDayEarly !== false;
     const cutoffMinutes = Number.isFinite(opts.previousDayCutoffMinutes)
@@ -2222,29 +2300,56 @@ module.exports = NodeHelper.create({
       : ((Number.isFinite(opts.previousDayCutoffHour) ? opts.previousDayCutoffHour * 60 : 9 * 60 + 30));
     const tz = this.config && this.config.timeZone ? this.config.timeZone : "America/Chicago";
     const now = new Date();
-    let dateIso = now.toLocaleDateString("en-CA", { timeZone: tz });
-    const timeCT  = now.toLocaleTimeString("en-GB", {
+    const todayIso = now.toLocaleDateString("en-CA", { timeZone: tz });
+    const timeStr = now.toLocaleTimeString("en-GB", {
       timeZone: tz,
       hour12: false,
       hour: "2-digit",
       minute: "2-digit"
     });
-    const [hStr, mStr] = timeCT.split(":");
+    const [hStr, mStr] = timeStr.split(":");
     const h = parseInt(hStr, 10);
     const m = parseInt(mStr, 10);
-
-    // Before the configured local cutoff, show yesterday's schedule (catch late finishes)
     const currentMinutes = (Number.isFinite(h) ? h : 0) * 60 + (Number.isFinite(m) ? m : 0);
-    if (usePreviousDayEarly && currentMinutes < cutoffMinutes) {
-      const dt = new Date(dateIso);
-      dt.setDate(dt.getDate() - 1);
-      dateIso = dt.toISOString().slice(0, 10);
-    }
+    const beforeUpdateCutoff = usePreviousDayEarly && currentMinutes < cutoffMinutes;
+    const previousDateIso = this._addDaysIso(todayIso, -1);
+    const scoreboardDateIso = beforeUpdateCutoff ? previousDateIso : todayIso;
 
     return {
-      dateIso,
-      dateCompact: dateIso.replace(/-/g, "")
+      todayIso,
+      previousDateIso,
+      scoreboardDateIso,
+      beforeUpdateCutoff,
+      cutoffMinutes,
+      dateIso: scoreboardDateIso,
+      dateCompact: scoreboardDateIso.replace(/-/g, ""),
+      todayCompact: todayIso.replace(/-/g, "")
     };
+  },
+
+  _addDaysIso(dateIso, days) {
+    const dt = new Date(`${dateIso}T00:00:00Z`);
+    dt.setUTCDate(dt.getUTCDate() + days);
+    return dt.toISOString().slice(0, 10);
+  },
+
+  _isFinalGame(game) {
+    if (!game || typeof game !== "object") return false;
+    const status = game.status || {};
+    const statusType = status.type || {};
+    const abstractState = String(status.abstractGameState || "").toLowerCase();
+    const detailedState = String(status.detailedState || "").toLowerCase();
+    const codedState = String(status.codedGameState || status.statusCode || "").toLowerCase();
+    if (abstractState === "final" || detailedState.indexOf("final") !== -1 || codedState === "f") return true;
+    if (statusType.completed === true || status.completed === true) return true;
+    const typeName = String(statusType.name || statusType.state || statusType.type || "").toLowerCase();
+    const description = String(statusType.description || statusType.detail || statusType.shortDetail || "").toLowerCase();
+    return typeName === "post" || typeName === "final" || description.indexOf("final") !== -1;
+  },
+
+  _finalGamesOnly(games) {
+    if (!Array.isArray(games)) return [];
+    return games.filter((game) => this._isFinalGame(game));
   },
 
   _getNhlScoreboardDate() {


### PR DESCRIPTION
### Motivation
- Ensure that in the early-morning window before the configured scoreboard update cutoff, scoreboards present the previous day's final results followed by a page showing the current day's schedule, then switch to the current-day scoreboard after the cutoff. 

### Description
- Added a cutoff-aware helper ` _getScoreboardDateContext` and small date utilities (`_addDaysIso`, `_isFinalGame`, `_finalGamesOnly`) in `node_helper.js` to compute `today`, `previous`, and `scoreboard` dates and whether we are before the update cutoff. 
- Updated league fetch flows (MLB/WBC, NHL, NBA, World Cup, NFL, Olympic hockey) to send previous-day final games when `beforeUpdateCutoff` is true and to also fetch/send `scheduleGames` (current-day schedule) alongside a `showingPreviousFinals` flag in the payload. 
- Front-end changes in `MMM-Scores.js` add `scheduleGamesByLeague` state, include schedule pages in page counts, and render a "Today's Schedule" rotation page after previous-final scoreboard pages using the existing scoreboard grid/cards. 
- Updated `README.md` to document the new cutoff behavior and how the module shows previous-day finals then a schedule screen before switching to current-day scoreboards after the cutoff.

### Testing
- Ran static JS checks with `node --check node_helper.js` which succeeded. 
- Ran static JS checks with `node --check MMM-Scores.js` which succeeded. 
- Ran `npm run test:api`; the test command executed but all upstream API connectivity checks failed due to network/DNS connectivity errors in the execution environment, so runtime integration checks could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46880a56108322a1ca0c102fe2ea7a)