### PR TITLE
Refactor helper fetches with timeouts & last-good cache; add shared league config, provider status UI, asset checker and tests

### DIFF
--- a/MMM-Scores.css
+++ b/MMM-Scores.css
@@ -691,3 +691,11 @@
 .scoreboard-card .team-highlight ~ .scoreboard-value.live {
   color: var(--scoreboard-value-color) !important;
 }
+
+.scoreboard-provider-status {
+  width: min(100%, var(--scoreboard-content-width, 100%));
+  text-align: center;
+  font-size: calc(var(--scoreboard-label-font) + 1pt);
+  letter-spacing: 0.08em;
+  color: var(--scoreboard-muted);
+}

--- a/MMM-Scores.js
+++ b/MMM-Scores.js
@@ -281,6 +281,15 @@
       highlightedTeams_oly_whockey:     [],
       showTitle:                        true,
       useTimesSquareFont:               true,
+      requestTimeoutMs:              15000,
+      lastGoodCacheMs:         6 * 60 * 60 * 1000,
+      seasonalFiltering:                true,
+      hideNhlDuringOlympics:            true,
+      hideNhlFrom:              "2026-02-06",
+      hideNhlUntil:             "2026-02-24",
+      hideOlympicsAfterEnd:             true,
+      hideOlympicsFrom:         "2026-02-24",
+      showProviderStatus:              false,
 
       // Width cap so it behaves in middle_center
       maxWidth:                      "800px"
@@ -303,7 +312,7 @@
     getScripts: function () {
       // MagicMirror already provides moment-timezone globally; avoid loading our own copy to
       // prevent clobbering other modules (e.g., the Calendar module relies on moment.tz).
-      return [];
+      return ["shared-league-config.js"];
     },
 
     getStyles: function () {
@@ -388,44 +397,35 @@
       return "mlb";
     },
 
+    _leagueConfig: function () {
+      return (typeof window !== "undefined" && window.MmmScoresLeagueConfig) ? window.MmmScoresLeagueConfig : null;
+    },
+
     _normalizeLeagueKey: function (value) {
+      var shared = this._leagueConfig();
+      if (shared) return shared.normalizeLeagueKey(value);
       if (value == null) return null;
       var str = String(value).trim().toLowerCase();
-      return (SUPPORTED_LEAGUES.indexOf(str) !== -1) ? str : null;
+      return SUPPORTED_LEAGUES.indexOf(str) !== -1 ? str : null;
     },
 
     _coerceLeagueArray: function (input) {
+      var shared = this._leagueConfig();
+      if (shared) return shared.coerceLeagueArray(input);
       var tokens = [];
       var collect = function (entry) {
         if (entry == null) return;
-        if (Array.isArray(entry)) {
-          for (var i = 0; i < entry.length; i++) collect(entry[i]);
-          return;
-        }
-        var str = String(entry).trim();
-        if (!str) return;
-        var parts = str.split(/[\s,]+/);
-        for (var j = 0; j < parts.length; j++) {
-          var part = parts[j].trim();
-          if (part) tokens.push(part);
-        }
+        if (Array.isArray(entry)) { for (var i = 0; i < entry.length; i++) collect(entry[i]); return; }
+        String(entry).trim().split(/[\s,]+/).forEach(function (part) { if (part) tokens.push(part); });
       };
       collect(input);
-
-      var normalized = [];
-      var seen = {};
+      var out = [], seen = {};
       for (var k = 0; k < tokens.length; k++) {
-        var token = tokens[k];
-        var lower = token.toLowerCase();
-        if (lower === "all") {
-          return SUPPORTED_LEAGUES.slice();
-        }
-        if (SUPPORTED_LEAGUES.indexOf(lower) !== -1 && !seen[lower]) {
-          normalized.push(lower);
-          seen[lower] = true;
-        }
+        var lower = String(tokens[k]).toLowerCase();
+        if (lower === "all") return SUPPORTED_LEAGUES.slice();
+        if (SUPPORTED_LEAGUES.indexOf(lower) !== -1 && !seen[lower]) { out.push(lower); seen[lower] = true; }
       }
-      return normalized;
+      return out;
     },
 
     _extractModulePosition: function () {
@@ -503,16 +503,17 @@
     },
 
     _resolveConfiguredLeagues: function () {
+      var shared = this._leagueConfig();
+      if (shared) return shared.resolveConfiguredLeagues(this.config || {}, this._todayIsoInTimeZone());
       var cfg = this.config || {};
       var source = (typeof cfg.leagues !== "undefined") ? cfg.leagues : cfg.league;
-      var leagues = this._coerceLeagueArray(source);
-      if (!Array.isArray(leagues)) return [];
-      return this._filterSeasonalLeagues(this._expandMlbLeagueFamily(leagues));
+      return this._filterSeasonalLeagues(this._expandMlbLeagueFamily(this._coerceLeagueArray(source)));
     },
 
     _expandMlbLeagueFamily: function (leagues) {
-      if (!Array.isArray(leagues) || leagues.length === 0) return [];
-      return leagues.slice();
+      var shared = this._leagueConfig();
+      if (shared) return shared.expandMlbLeagueFamily(leagues);
+      return Array.isArray(leagues) ? leagues.slice() : [];
     },
 
     _rebuildLeagueRotation: function (preferredLeague) {
@@ -547,17 +548,23 @@
     },
 
     _isNhlBreakWindow: function (dateIso) {
-      return dateIso >= "2026-02-06" && dateIso <= "2026-02-24";
+      var shared = this._leagueConfig();
+      if (shared) return shared.isNhlBreakWindow(dateIso, this.config || {});
+      return dateIso >= (this.config.hideNhlFrom || "2026-02-06") && dateIso <= (this.config.hideNhlUntil || "2026-02-24");
     },
 
     _hideOlympicScoreboards: function (dateIso) {
-      return dateIso >= "2026-02-24";
+      var shared = this._leagueConfig();
+      if (shared) return shared.hideOlympicScoreboards(dateIso, this.config || {});
+      return dateIso >= (this.config.hideOlympicsFrom || "2026-02-24");
     },
 
     _filterSeasonalLeagues: function (leagues) {
+      var shared = this._leagueConfig();
+      if (shared) return shared.filterSeasonalLeagues(leagues, this.config || {}, this._todayIsoInTimeZone());
       var dateIso = this._todayIsoInTimeZone();
-      var hideNhl = this._isNhlBreakWindow(dateIso);
-      var hideOlympics = this._hideOlympicScoreboards(dateIso);
+      var hideNhl = this.config.seasonalFiltering !== false && this._isNhlBreakWindow(dateIso);
+      var hideOlympics = this.config.seasonalFiltering !== false && this._hideOlympicScoreboards(dateIso);
 
       return leagues.filter(function (league) {
         if (hideNhl && league === "nhl") return false;
@@ -575,6 +582,7 @@
       payload.activeLeague = this._getLeague();
       return payload;
     },
+
     _applyActiveLeagueState: function () {
       this._syncScoreboardLayout();
       var league = this._getLeague();
@@ -1355,6 +1363,24 @@
       return wrapper;
     },
 
+    _buildProviderStatus: function () {
+      var extras = this.currentExtras || {};
+      var shouldShow = this.config.showProviderStatus === true || extras.isStale || extras.fallbackUsed;
+      if (!shouldShow) return null;
+      var parts = [];
+      if (extras.isStale) parts.push("Showing cached data");
+      else if (extras.fallbackUsed) parts.push("Using fallback feed");
+      if (extras.provider || extras.providerUsed) parts.push("Source: " + (extras.provider || extras.providerUsed));
+      var stamp = extras.lastUpdatedAt || extras.fetchedAt || extras.fetchedAtUTC;
+      if (stamp) parts.push("Updated " + new Date(stamp).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }));
+      if (extras.staleReason && extras.isStale) parts.push(extras.staleReason);
+      if (parts.length === 0) return null;
+      var div = document.createElement("div");
+      div.className = "scoreboard-provider-status small dimmed";
+      div.innerText = parts.join(" • ");
+      return div;
+    },
+
     // ----------------- SCOREBOARD -----------------
     _buildGames: function () {
       this._syncScoreboardLayout();
@@ -1382,6 +1408,9 @@
       }
 
       this._setModuleContentWidth(widthPx);
+
+      var providerStatus = this._buildProviderStatus();
+      if (providerStatus) container.appendChild(providerStatus);
 
       var scoreboardPages = this._scoreboardPageCount || 0;
       var scoreboardRendered = false;

--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ Place any custom logos or font files as described below, then add the module to 
 ---
 
 ## API Connectivity Check
+Run the offline unit tests for shared league/date logic:
+```bash
+npm test
+```
+
 Use this script to verify that every external API endpoint used by the helper is reachable from your host:
 ```bash
 npm run test:api
@@ -59,6 +64,11 @@ The command checks MLB, NHL (all fallback feeds), NFL, NBA, World Cup soccer, an
 Use this Olympic-focused diagnostics script to check provider reachability and print normalized men's/women's Olympic games for a target date:
 ```bash
 npm run test:olympic -- 2026-02-11
+```
+
+Validate bundled font/logo assets without hitting network APIs:
+```bash
+npm run check:assets
 ```
 
 ---
@@ -96,6 +106,14 @@ Every option may be declared globally, as an object keyed by league (`{ mlb: val
 | `rotateIntervalScores` | `number` | `15000` | Milliseconds between scoreboard page rotations. |
 | `timeZone` | `string` | `"America/Chicago"` | Time zone used to decide the scoreboard date. Before the configured daily update cutoff (09:30 local for most leagues, 03:00 for Olympic hockey), scoreboards show previous-day final scores and then rotate to a current-day schedule screen; after the cutoff they show the current day's scoreboard. |
 | `providerCacheMs` | `number` | `20000` | Per-provider/per-date Olympic provider cache TTL in milliseconds (minimum 15000). |
+| `requestTimeoutMs` | `number` | `15000` | Maximum time in milliseconds for each helper HTTP request before it is aborted. |
+| `lastGoodCacheMs` | `number` | `21600000` | How long a last successful response can be reused if a provider fails; stale payloads are flagged for the UI. |
+| `seasonalFiltering` | `boolean` | `true` | Enables automatic hiding for known seasonal windows such as the 2026 NHL Olympic break and Olympic scoreboard retirement. |
+| `hideNhlDuringOlympics` | `boolean` | `true` | Hide NHL while the configured NHL break window is active. |
+| `hideNhlFrom` / `hideNhlUntil` | `string` | `"2026-02-06"` / `"2026-02-24"` | Inclusive ISO dates for the NHL Olympic-break visibility window. |
+| `hideOlympicsAfterEnd` | `boolean` | `true` | Hide Olympic hockey scoreboards after the configured Olympic end date. |
+| `hideOlympicsFrom` | `string` | `"2026-02-24"` | ISO date when Olympic hockey scoreboards are hidden unless seasonal filtering is disabled. |
+| `showProviderStatus` | `boolean` | `false` | Shows a compact source/updated/stale-data line above the scoreboards; stale fallback data is always indicated. |
 | `scoreboardColumns` | `number` | auto | Columns per page. Defaults to 2 for MLB (capped at 2) and 4 for NHL/NFL/NBA/World Cup/Olympic hockey. |
 | `gamesPerColumn` (`scoreboardRows`) | `number` | auto | Games stacked in each column (4 for all leagues unless overridden). |
 | `gamesPerPage` | `number` | derived | Override the total games per page; rows adjust automatically per league. |
@@ -110,7 +128,26 @@ Every option may be declared globally, as an object keyed by league (`{ mlb: val
 - **Object form**: For `layoutScale` or highlight lists, you can pass an object with `default` and per-league keys.
 
 ### League rotation
-The module keeps an internal rotation list derived from `league`/`leagues`. It fetches games for every configured league on each helper poll and flips the front-end page every `rotateIntervalScores` milliseconds.
+The module keeps an internal rotation list derived from `league`/`leagues`. It fetches games for every configured league on each helper poll and flips the front-end page every `rotateIntervalScores` milliseconds. Helper fetches run independently so one slow provider does not block the rest of the rotation.
+
+### Provider resilience and seasonal visibility
+All helper HTTP requests use `requestTimeoutMs` and validated HTTP status handling. When a provider fails, the helper reuses the most recent successful payload for that league until `lastGoodCacheMs` expires and marks the data as stale. Set `showProviderStatus: true` to show source/update metadata even when data is fresh; stale fallback data is shown automatically.
+
+Seasonal filtering is configurable. For example, keep NHL and Olympic boards visible regardless of the built-in 2026 windows:
+```js
+config: {
+  league: "all",
+  seasonalFiltering: false
+}
+```
+Or customize the dates:
+```js
+config: {
+  hideNhlFrom: "2026-02-06",
+  hideNhlUntil: "2026-02-24",
+  hideOlympicsFrom: "2026-02-25"
+}
+```
 
 ### Highlighting
 Highlight any number of teams per league using the appropriate `_mlb`, `_nhl`, `_nfl`, `_nba`, `_worldcup`, `_olympic_mhockey` (or `_oly_mhockey`), or `_olympic_whockey` (or `_oly_whockey`) suffix. Highlights apply to scoreboards.
@@ -142,6 +179,7 @@ MMM-Scores/
 - **Logos**: Place transparent PNG logos named with the abbreviations used in-game data (`CUBS.png`, `NYR.png`, `kc.png`, `CHI.png`, etc.). The module falls back to text when a logo is missing. Olympic men's/women's hockey and World Cup soccer read from `images/oly/<CODE>.png` (for example `CAN.png`, `USA.png`, `SWE.png`).
 - **Font**: Drop `fonts/TimesSquare-m105.ttf` into `fonts/`. The CSS registers it with `@font-face`.
 - **Styling tweaks**: Override CSS variables in `MMM-Scores.css` or globally (e.g., `css/custom.css`). Useful variables include `--scoreboard-card-width-base`, `--scoreboard-team-font-base`, `--scoreboard-value-font-base`, `--scoreboard-gap-base`, and `--matrix-gap-base`.
+- **Asset diagnostics**: Run `npm run check:assets` after adding logos or fonts. The command verifies required folders/files and warns about case-colliding PNG names that can behave differently across filesystems.
 
 Example:
 ```css

--- a/node_helper.js
+++ b/node_helper.js
@@ -5,6 +5,7 @@ const cheerio    = require("cheerio");
 const http       = require("http");
 const https      = require("https");
 const { URL }    = require("url");
+const LeagueConfig = require("./shared-league-config");
 
 function createHttpFetchFallback(maxRedirects = 5) {
   const requestOnce = (url, options, redirectsLeft) => new Promise((resolve, reject) => {
@@ -61,7 +62,7 @@ const fetch = (typeof global.fetch === "function")
   ? global.fetch.bind(global)
   : createHttpFetchFallback();
 
-const SUPPORTED_LEAGUES = ["mlb", "wbc", "nhl", "nfl", "nba", "worldcup", "olympic_mhockey", "olympic_whockey"];
+const { SUPPORTED_LEAGUES } = LeagueConfig;
 const MLB_SCOREBOARD_SPORT_IDS = [1, 51]; // MLB plus explicit international/WBC feeds, split before display
 const MLB_INTERNATIONAL_WBC_TEAM_IDS = new Set([
   776, // Brazil
@@ -130,6 +131,7 @@ module.exports = NodeHelper.create({
     this._nhlStatsRestStatus = { available: null, checkedAt: 0, warnedAt: 0 };
     this._providerCache = new Map();
     this._olympicLastGoodByLeague = {};
+    this._lastGoodByLeague = {};
   },
 
   socketNotificationReceived(notification, payload) {
@@ -152,34 +154,81 @@ module.exports = NodeHelper.create({
     }
   },
 
+
+  _requestTimeoutMs() {
+    const raw = Number(this.config && this.config.requestTimeoutMs);
+    return Number.isFinite(raw) && raw > 0 ? raw : 15000;
+  },
+
+  async _fetchResponse(url, options = {}, label = url) {
+    const timeoutMs = this._requestTimeoutMs();
+    const started = Date.now();
+    let timer = null;
+    let controller = null;
+    const requestOptions = Object.assign({}, options || {});
+
+    if (typeof AbortController !== "undefined") {
+      controller = new AbortController();
+      requestOptions.signal = controller.signal;
+      timer = setTimeout(() => controller.abort(), timeoutMs);
+    }
+
+    try {
+      const res = await fetch(url, requestOptions);
+      const elapsedMs = Date.now() - started;
+      if (!res || !res.ok) {
+        const status = res && typeof res.status !== "undefined" ? res.status : "?";
+        const statusText = res && res.statusText ? res.statusText : "";
+        throw new Error(`${label} failed with HTTP ${status} ${statusText} (${elapsedMs}ms)`);
+      }
+      return res;
+    } catch (err) {
+      if (err && err.name === "AbortError") {
+        throw new Error(`${label} timed out after ${timeoutMs}ms`);
+      }
+      throw err;
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  },
+
+  async _fetchJson(url, options = {}, label = url) {
+    const res = await this._fetchResponse(url, options, label);
+    return res.json();
+  },
+
+  async _fetchText(url, options = {}, label = url) {
+    const res = await this._fetchResponse(url, options, label);
+    return res.text();
+  },
   async _fetchGames() {
     const leagues = Array.isArray(this.leagues) && this.leagues.length > 0
       ? this.leagues
       : [this._getLeague()];
 
-    for (let i = 0; i < leagues.length; i++) {
-      const league = leagues[i];
-      try {
-        if (league === "nhl") {
-          await this._fetchNhlGames();
-        } else if (league === "olympic_mhockey") {
-          await this._fetchOlympicHockeyGames("olympic_mhockey");
-        } else if (league === "olympic_whockey") {
-          await this._fetchOlympicHockeyGames("olympic_whockey");
-        } else if (league === "nfl") {
-          await this._fetchNflGames();
-        } else if (league === "nba") {
-          await this._fetchNbaGames();
-        } else if (league === "worldcup") {
-          await this._fetchWorldCupGames();
-        } else {
-          await this._fetchMlbGames();
-        }
-      } catch (err) {
-        console.error(`🚨 ${league} fetch loop failed:`, err);
-        this._notifyGames(league, []);
+    // League fetches are intentionally independent so one slow provider does not
+    // block the entire MagicMirror rotation.
+    const unique = Array.from(new Set(leagues.map((league) => league === "wbc" ? "mlb" : league)));
+    const tasks = unique.map((league) => this._fetchLeagueGames(league));
+    const results = await Promise.allSettled(tasks);
+
+    results.forEach((result, index) => {
+      if (result.status === "rejected") {
+        const league = unique[index];
+        console.error(`🚨 ${league} fetch loop failed:`, result.reason);
+        this._notifyGamesWithFallback(league, [], { errorMessage: result.reason && result.reason.message });
       }
-    }
+    });
+  },
+
+  async _fetchLeagueGames(league) {
+    if (league === "nhl") return this._fetchNhlGames();
+    if (league === "olympic_mhockey") return this._fetchOlympicHockeyGames("olympic_mhockey");
+    if (league === "olympic_whockey") return this._fetchOlympicHockeyGames("olympic_whockey");
+    if (league === "nfl") return this._fetchNflGames();
+    if (league === "nba") return this._fetchNbaGames();
+    if (league === "worldcup") return this._fetchWorldCupGames();
+    return this._fetchMlbGames();
   },
 
   async _fetchMlbGames() {
@@ -189,24 +238,18 @@ module.exports = NodeHelper.create({
       const gamesByPk = new Map();
       const scheduleByPk = new Map();
 
-      for (const sportId of MLB_SCOREBOARD_SPORT_IDS) {
-        const games = await this._fetchMlbGamesBySport(dateIso, sportId);
-        for (let i = 0; i < games.length; i += 1) {
-          const game = games[i];
-          const gamePk = Number(game && game.gamePk);
-          if (Number.isFinite(gamePk)) {
-            gamesByPk.set(gamePk, game);
-          }
-        }
+      const displayResults = await Promise.all(MLB_SCOREBOARD_SPORT_IDS.map((sportId) => this._fetchMlbGamesBySport(dateIso, sportId)));
+      displayResults.flat().forEach((game) => {
+        const gamePk = Number(game && game.gamePk);
+        if (Number.isFinite(gamePk)) gamesByPk.set(gamePk, game);
+      });
 
-        if (context.beforeUpdateCutoff) {
-          const scheduleGames = await this._fetchMlbGamesBySport(context.todayIso, sportId);
-          for (let i = 0; i < scheduleGames.length; i += 1) {
-            const game = scheduleGames[i];
-            const gamePk = Number(game && game.gamePk);
-            if (Number.isFinite(gamePk)) scheduleByPk.set(gamePk, game);
-          }
-        }
+      if (context.beforeUpdateCutoff) {
+        const scheduleResults = await Promise.all(MLB_SCOREBOARD_SPORT_IDS.map((sportId) => this._fetchMlbGamesBySport(context.todayIso, sportId)));
+        scheduleResults.flat().forEach((game) => {
+          const gamePk = Number(game && game.gamePk);
+          if (Number.isFinite(gamePk)) scheduleByPk.set(gamePk, game);
+        });
       }
 
       const games = Array.from(gamesByPk.values()).sort((a, b) => {
@@ -233,8 +276,8 @@ module.exports = NodeHelper.create({
       this._notifyGames("wbc", separatedGames.wbc, { scheduleGames: separatedSchedule.wbc, showingPreviousFinals: context.beforeUpdateCutoff });
     } catch (e) {
       console.error("🚨 MLB fetchGames failed:", e);
-      this._notifyGames("mlb", []);
-      this._notifyGames("wbc", []);
+      this._notifyGamesWithFallback("mlb", [], { errorMessage: e.message });
+      this._notifyGamesWithFallback("wbc", [], { errorMessage: e.message });
     }
   },
 
@@ -259,12 +302,7 @@ module.exports = NodeHelper.create({
 
   async _fetchMlbGamesBySport(dateIso, sportId) {
     const url = `https://statsapi.mlb.com/api/v1/schedule/games?sportId=${sportId}&date=${dateIso}&hydrate=linescore`;
-    const res = await fetch(url);
-    if (!res.ok) {
-      throw new Error(`HTTP ${res.status} ${res.statusText} (sportId=${sportId})`);
-    }
-
-    const json = await res.json();
+    const json = await this._fetchJson(url, {}, `MLB sportId=${sportId}`);
     const games = [];
     const dates = Array.isArray(json && json.dates) ? json.dates : [];
 
@@ -399,7 +437,7 @@ module.exports = NodeHelper.create({
 
     if (!delivered && !sent) {
       console.warn(`⚠️ Unable to fetch NHL games for ${targetDate}; sending empty schedule to front-end.`);
-      this._notifyGames("nhl", []);
+      this._notifyGamesWithFallback("nhl", [], { errorMessage: "Unable to fetch NHL games" });
     }
   },
 
@@ -436,12 +474,7 @@ module.exports = NodeHelper.create({
 
   async _fetchNhlStatsGames(dateIso) {
     const url = `https://statsapi.web.nhl.com/api/v1/schedule?date=${dateIso}&expand=schedule.linescore,schedule.teams`;
-    const res  = await fetch(url, { headers: this._nhlRequestHeaders() });
-    if (!res.ok) {
-      throw new Error(`HTTP ${res.status} ${res.statusText}`);
-    }
-
-    const json = await res.json();
+    const json = await this._fetchJson(url, { headers: this._nhlRequestHeaders() }, "NHL stats API");
     const dates = Array.isArray(json.dates) ? json.dates : [];
     const games = [];
     for (let i = 0; i < dates.length; i += 1) {
@@ -469,12 +502,7 @@ module.exports = NodeHelper.create({
     for (let u = 0; u < urls.length; u += 1) {
       const fallbackUrl = urls[u];
       try {
-        const res = await fetch(fallbackUrl, { headers });
-        if (!res.ok) {
-          throw new Error(`HTTP ${res.status} ${res.statusText}`);
-        }
-
-        const json = await res.json();
+        const json = await this._fetchJson(fallbackUrl, { headers }, `NHL scoreboard API ${u + 1}`);
         const rawGames = this._collectNhlScoreboardGames(json, dateIso);
         const normalized = [];
 
@@ -639,18 +667,16 @@ module.exports = NodeHelper.create({
     }
 
     const restUrl = `https://api.nhle.com/stats/rest/en/schedule?cayenneExp=gameDate=%22${dateIso}%22`;
-    const res = await fetch(restUrl, { headers: this._nhlRequestHeaders({
-      "x-nhl-stats-origin": "https://www.nhl.com",
-      "x-nhl-stats-referer": "https://www.nhl.com"
-    }) });
-    if (!res.ok) {
-      if (res.status === 404) {
-        this._markNhlStatsRestUnavailable();
-      }
-      throw new Error(`HTTP ${res.status} ${res.statusText}`);
+    let json;
+    try {
+      json = await this._fetchJson(restUrl, { headers: this._nhlRequestHeaders({
+        "x-nhl-stats-origin": "https://www.nhl.com",
+        "x-nhl-stats-referer": "https://www.nhl.com"
+      }) }, "NHL stats REST API");
+    } catch (err) {
+      if (/HTTP 404/.test(String(err && err.message))) this._markNhlStatsRestUnavailable();
+      throw err;
     }
-
-    const json = await res.json();
     const rawGames = Array.isArray(json.data) ? json.data : [];
     const normalized = [];
 
@@ -1310,23 +1336,19 @@ module.exports = NodeHelper.create({
     } catch (e) {
       console.error(`🚨 ${leagueKey} fetchGames failed:`, e);
       const fallbackGames = Array.isArray(this._olympicLastGoodByLeague[leagueKey]) ? this._olympicLastGoodByLeague[leagueKey] : [];
-      this._notifyGames(leagueKey, this._normalizedGamesToLegacyEvents(fallbackGames));
+      this._notifyGamesWithFallback(leagueKey, this._normalizedGamesToLegacyEvents(fallbackGames), { errorMessage: e.message });
     }
   },
 
   async fetchOlympicScoreboardMen(dateIso, dateCompact) {
     const url = `https://site.api.espn.com/apis/site/v2/sports/hockey/mens-olympics/scoreboard?dates=${dateCompact || String(dateIso || "").replace(/-/g, "")}`;
-    const res = await fetch(url);
-    if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
-    const json = await res.json();
+    const json = await this._fetchJson(url, {}, "Olympic men's ESPN scoreboard");
     return this.normalizeEspnOlympicResponse(json, "olympic_mhockey", "espn_mens_olympics");
   },
 
   async fetchOlympicScoreboardWomen(dateIso, dateCompact) {
     const url = `https://site.api.espn.com/apis/site/v2/sports/hockey/womens-olympics/scoreboard?dates=${dateCompact || String(dateIso || "").replace(/-/g, "")}`;
-    const res = await fetch(url);
-    if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
-    const json = await res.json();
+    const json = await this._fetchJson(url, {}, "Olympic women's ESPN scoreboard");
     return this.normalizeEspnOlympicResponse(json, "olympic_whockey", "espn_womens_olympics");
   },
 
@@ -1499,19 +1521,13 @@ module.exports = NodeHelper.create({
     for (let i = 0; i < urls.length; i += 1) {
       const url = urls[i];
       try {
-        const res = await fetch(url, {
+        const html = await this._fetchText(url, {
           headers: {
             "user-agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
             "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
             "accept-language": "en-US,en;q=0.9"
           }
-        });
-
-        if (!res.ok) {
-          throw new Error(`HTTP ${res.status} ${res.statusText}`);
-        }
-
-        const html = await res.text();
+        }, "Olympic ESPN results page");
         const roots = this._extractEspnPageStatePayloads(html);
         const rawGames = [];
 
@@ -1742,11 +1758,7 @@ module.exports = NodeHelper.create({
       const context = this._getScoreboardDateContext();
       const { dateIso, dateCompact } = context;
       const url = `https://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard?dates=${dateCompact}`;
-      const res = await fetch(url);
-      if (!res.ok) {
-        throw new Error(`HTTP ${res.status} ${res.statusText}`);
-      }
-      const json = await res.json();
+      const json = await this._fetchJson(url, {}, "NBA ESPN scoreboard");
       const events = this._collectEspnScoreboardEvents(json);
 
       events.sort((a, b) => {
@@ -1772,15 +1784,18 @@ module.exports = NodeHelper.create({
       let scheduleGames = [];
       if (context.beforeUpdateCutoff) {
         const scheduleUrl = `https://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard?dates=${context.todayCompact}`;
-        const scheduleRes = await fetch(scheduleUrl);
-        if (scheduleRes.ok) scheduleGames = this._collectEspnScoreboardEvents(await scheduleRes.json());
+        try {
+          scheduleGames = this._collectEspnScoreboardEvents(await this._fetchJson(scheduleUrl, {}, scheduleUrl));
+        } catch (scheduleError) {
+          console.warn(`⚠️ Schedule fetch failed for ${context.todayIso}:`, scheduleError.message || scheduleError);
+        }
       }
       const displayEvents = context.beforeUpdateCutoff ? this._finalGamesOnly(events) : events;
       console.log(`🏀 Sending ${displayEvents.length} NBA games for ${dateIso} to front-end.`);
       this._notifyGames("nba", displayEvents, { scheduleGames, showingPreviousFinals: context.beforeUpdateCutoff });
     } catch (e) {
       console.error("🚨 NBA fetchGames failed:", e);
-      this._notifyGames("nba", []);
+      this._notifyGamesWithFallback("nba", [], { errorMessage: e.message });
     }
   },
 
@@ -1818,12 +1833,7 @@ module.exports = NodeHelper.create({
       const context = this._getScoreboardDateContext();
       const { dateIso, dateCompact } = context;
       const url = `https://site.api.espn.com/apis/site/v2/sports/soccer/fifa.world/scoreboard?dates=${dateCompact}`;
-      const res = await fetch(url);
-      if (!res.ok) {
-        throw new Error(`HTTP ${res.status} ${res.statusText}`);
-      }
-
-      const json = await res.json();
+      const json = await this._fetchJson(url, {}, url);
       const events = this._collectEspnScoreboardEvents(json);
 
       events.sort((a, b) => {
@@ -1849,15 +1859,18 @@ module.exports = NodeHelper.create({
       let scheduleGames = [];
       if (context.beforeUpdateCutoff) {
         const scheduleUrl = `https://site.api.espn.com/apis/site/v2/sports/soccer/fifa.world/scoreboard?dates=${context.todayCompact}`;
-        const scheduleRes = await fetch(scheduleUrl);
-        if (scheduleRes.ok) scheduleGames = this._collectEspnScoreboardEvents(await scheduleRes.json());
+        try {
+          scheduleGames = this._collectEspnScoreboardEvents(await this._fetchJson(scheduleUrl, {}, scheduleUrl));
+        } catch (scheduleError) {
+          console.warn(`⚠️ Schedule fetch failed for ${context.todayIso}:`, scheduleError.message || scheduleError);
+        }
       }
       const displayEvents = context.beforeUpdateCutoff ? this._finalGamesOnly(events) : events;
       console.log(`⚽ Sending ${displayEvents.length} World Cup games for ${dateIso} to front-end.`);
       this._notifyGames("worldcup", displayEvents, { scheduleGames, showingPreviousFinals: context.beforeUpdateCutoff });
     } catch (e) {
       console.error("🚨 World Cup fetchGames failed:", e);
-      this._notifyGames("worldcup", []);
+      this._notifyGamesWithFallback("worldcup", [], { errorMessage: e.message });
     }
   },
 
@@ -1924,7 +1937,7 @@ module.exports = NodeHelper.create({
       this._notifyGames("nfl", games, extras);
     } catch (e) {
       console.error("🚨 NFL fetchGames failed:", e);
-      this._notifyGames("nfl", [], { teamsOnBye: [] });
+      this._notifyGamesWithFallback("nfl", [], { teamsOnBye: [], errorMessage: e.message });
     }
   },
 
@@ -1932,19 +1945,19 @@ module.exports = NodeHelper.create({
     const aggregated = new Map();
     const byeTeams = new Map();
 
-    for (let i = 0; i < dateIsos.length; i += 1) {
-      const dateIso = dateIsos[i];
+    const results = await Promise.allSettled(dateIsos.map(async (dateIso) => {
       const dateCompact = dateIso.replace(/-/g, "");
       const url = `https://site.api.espn.com/apis/site/v2/sports/football/nfl/scoreboard?dates=${dateCompact}`;
+      return { dateIso, json: await this._fetchJson(url, {}, `NFL scoreboard ${dateIso}`) };
+    }));
 
-      try {
-        const res = await fetch(url);
-        const json = await res.json();
-        this._mergeNflScoreboardResponse(json, aggregated, byeTeams, dateIso);
-      } catch (err) {
-        console.error(`🚨 NFL fetchGames failed for ${dateIso}:`, err);
+    results.forEach((result) => {
+      if (result.status === "fulfilled") {
+        this._mergeNflScoreboardResponse(result.value.json, aggregated, byeTeams, result.value.dateIso);
+      } else {
+        console.error("🚨 NFL fetchGames failed for one date:", result.reason);
       }
-    }
+    });
 
     return this._finalizeNflWeekResults(aggregated, byeTeams);
   },
@@ -1955,8 +1968,7 @@ module.exports = NodeHelper.create({
     const url = "https://site.api.espn.com/apis/site/v2/sports/football/nfl/scoreboard";
 
     try {
-      const res = await fetch(url);
-      const json = await res.json();
+      const json = await this._fetchJson(url, {}, "NFL default scoreboard");
       this._mergeNflScoreboardResponse(json, aggregated, byeTeams, "current");
     } catch (err) {
       console.error("🚨 NFL fallback scoreboard fetch failed:", err);
@@ -2192,7 +2204,11 @@ module.exports = NodeHelper.create({
       normalizedGames = [];
     }
 
-    const payload = { league: normalizedLeague, games: normalizedGames };
+    const payload = {
+      league: normalizedLeague,
+      games: normalizedGames,
+      fetchedAt: new Date().toISOString()
+    };
 
     if (extras && typeof extras === "object") {
       Object.keys(extras).forEach((key) => {
@@ -2200,63 +2216,52 @@ module.exports = NodeHelper.create({
       });
     }
 
+    if (!payload.isStale && (normalizedGames.length > 0 || (payload.scheduleGames && payload.scheduleGames.length > 0))) {
+      if (!this._lastGoodByLeague) this._lastGoodByLeague = {};
+      this._lastGoodByLeague[normalizedLeague] = Object.assign({}, payload, {
+        games: normalizedGames.slice(),
+        scheduleGames: Array.isArray(payload.scheduleGames) ? payload.scheduleGames.slice() : payload.scheduleGames,
+        lastUpdatedAt: payload.fetchedAt
+      });
+    }
+
     this.sendSocketNotification("GAMES", payload);
   },
 
+  _notifyGamesWithFallback(league, games = [], extras = null) {
+    const normalizedLeague = this._normalizeLeagueKey(league) || this._getLeague();
+    const cache = this._lastGoodByLeague && this._lastGoodByLeague[normalizedLeague];
+    const ttlRaw = Number(this.config && this.config.lastGoodCacheMs);
+    const ttlMs = Number.isFinite(ttlRaw) && ttlRaw > 0 ? ttlRaw : 6 * 60 * 60 * 1000;
+    if (cache && cache.lastUpdatedAt && (Date.now() - Date.parse(cache.lastUpdatedAt)) <= ttlMs) {
+      const payload = Object.assign({}, cache, extras || {}, {
+        league: normalizedLeague,
+        isStale: true,
+        fallbackUsed: true,
+        staleReason: extras && extras.errorMessage ? extras.errorMessage : "Using last successful scoreboard response",
+        fetchedAt: new Date().toISOString(),
+        games: Array.isArray(cache.games) ? cache.games.slice() : []
+      });
+      this.sendSocketNotification("GAMES", payload);
+      return;
+    }
+    this._notifyGames(normalizedLeague, games, extras);
+  },
+
   _normalizeLeagueKey(value) {
-    if (value == null) return null;
-    const str = String(value).trim().toLowerCase();
-    return SUPPORTED_LEAGUES.includes(str) ? str : null;
+    return LeagueConfig.normalizeLeagueKey(value);
   },
 
   _coerceLeagueArray(input) {
-    const tokens = [];
-    const collect = (entry) => {
-      if (entry == null) return;
-      if (Array.isArray(entry)) {
-        for (let i = 0; i < entry.length; i += 1) collect(entry[i]);
-        return;
-      }
-      const str = String(entry).trim();
-      if (!str) return;
-      const parts = str.split(/[\s,]+/);
-      for (let j = 0; j < parts.length; j += 1) {
-        const part = parts[j].trim();
-        if (part) tokens.push(part);
-      }
-    };
-
-    collect(input);
-
-    const normalized = [];
-    const seen = new Set();
-    for (let k = 0; k < tokens.length; k += 1) {
-      const token = tokens[k];
-      const lower = token.toLowerCase();
-      if (lower === "all") {
-        return SUPPORTED_LEAGUES.slice();
-      }
-      if (SUPPORTED_LEAGUES.includes(lower) && !seen.has(lower)) {
-        normalized.push(lower);
-        seen.add(lower);
-      }
-    }
-    return normalized;
+    return LeagueConfig.coerceLeagueArray(input);
   },
 
   _resolveConfiguredLeagues() {
-    const cfg = this.config || {};
-    const source = (typeof cfg.leagues !== "undefined") ? cfg.leagues : cfg.league;
-    const leagues = this._coerceLeagueArray(source);
-    if (!Array.isArray(leagues)) return [];
-    return this._filterSeasonalLeagues(this._expandMlbLeagueFamily(leagues));
+    return LeagueConfig.resolveConfiguredLeagues(this.config || {}, this._todayIsoInTimeZone());
   },
 
-
-
   _expandMlbLeagueFamily(leagues) {
-    if (!Array.isArray(leagues) || leagues.length === 0) return [];
-    return leagues.slice();
+    return LeagueConfig.expandMlbLeagueFamily(leagues);
   },
 
   _todayIsoInTimeZone() {
@@ -2265,23 +2270,15 @@ module.exports = NodeHelper.create({
   },
 
   _isNhlBreakWindow(dateIso) {
-    return dateIso >= "2026-02-06" && dateIso <= "2026-02-24";
+    return LeagueConfig.isNhlBreakWindow(dateIso, this.config || {});
   },
 
   _hideOlympicScoreboards(dateIso) {
-    return dateIso >= "2026-02-24";
+    return LeagueConfig.hideOlympicScoreboards(dateIso, this.config || {});
   },
 
   _filterSeasonalLeagues(leagues) {
-    const dateIso = this._todayIsoInTimeZone();
-    const hideNhl = this._isNhlBreakWindow(dateIso);
-    const hideOlympics = this._hideOlympicScoreboards(dateIso);
-
-    return leagues.filter((league) => {
-      if (hideNhl && league === "nhl") return false;
-      if (hideOlympics && (league === "olympic_mhockey" || league === "olympic_whockey")) return false;
-      return true;
-    });
+    return LeagueConfig.filterSeasonalLeagues(leagues, this.config || {}, this._todayIsoInTimeZone());
   },
 
   _getTargetDate(options) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "MMM-Scores.js",
   "scripts": {
     "test:api": "node scripts/test-api-connections.js",
-    "test:olympic": "node scripts/test-olympic-hockey.js"
+    "test:olympic": "node scripts/test-olympic-hockey.js",
+    "test": "node --test test/*.test.js",
+    "check:assets": "node scripts/check-assets.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/check-assets.js
+++ b/scripts/check-assets.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const requiredPaths = [
+  'fonts/TimesSquare-m105.ttf',
+  'images/mlb',
+  'images/nhl',
+  'images/nfl',
+  'images/nba',
+  'images/oly'
+];
+
+let failures = 0;
+function check(condition, message) {
+  if (condition) console.log(`✅ ${message}`);
+  else { console.error(`❌ ${message}`); failures += 1; }
+}
+
+for (const rel of requiredPaths) {
+  check(fs.existsSync(path.join(ROOT, rel)), `${rel} exists`);
+}
+
+const dirs = ['images/mlb', 'images/nhl', 'images/nfl', 'images/nba', 'images/oly'];
+for (const rel of dirs) {
+  const dir = path.join(ROOT, rel);
+  if (!fs.existsSync(dir)) continue;
+  const files = fs.readdirSync(dir).filter((name) => name.toLowerCase().endsWith('.png'));
+  check(files.length > 0, `${rel} contains PNG assets`);
+
+  const lowerSeen = new Map();
+  for (const file of files) {
+    const lower = file.toLowerCase();
+    if (lowerSeen.has(lower) && lowerSeen.get(lower) !== file) {
+      console.warn(`⚠️ ${rel} has case-colliding files: ${lowerSeen.get(lower)} and ${file}`);
+    }
+    lowerSeen.set(lower, file);
+  }
+}
+
+if (failures > 0) process.exitCode = 1;
+else console.log('All asset checks passed.');

--- a/shared-league-config.js
+++ b/shared-league-config.js
@@ -1,0 +1,107 @@
+(function (root, factory) {
+  if (typeof module === "object" && module.exports) module.exports = factory();
+  else root.MmmScoresLeagueConfig = factory();
+}(typeof self !== "undefined" ? self : this, function () {
+  "use strict";
+
+  var SUPPORTED_LEAGUES = ["mlb", "wbc", "nhl", "nfl", "nba", "worldcup", "olympic_mhockey", "olympic_whockey"];
+
+  function normalizeLeagueKey(value) {
+    if (value == null) return null;
+    var str = String(value).trim().toLowerCase();
+    return SUPPORTED_LEAGUES.indexOf(str) !== -1 ? str : null;
+  }
+
+  function coerceLeagueArray(input) {
+    var tokens = [];
+    function collect(entry) {
+      if (entry == null) return;
+      if (Array.isArray(entry)) {
+        for (var i = 0; i < entry.length; i += 1) collect(entry[i]);
+        return;
+      }
+      var str = String(entry).trim();
+      if (!str) return;
+      var parts = str.split(/[\s,]+/);
+      for (var j = 0; j < parts.length; j += 1) {
+        var part = parts[j].trim();
+        if (part) tokens.push(part);
+      }
+    }
+    collect(input);
+
+    var normalized = [];
+    var seen = {};
+    for (var k = 0; k < tokens.length; k += 1) {
+      var lower = String(tokens[k]).toLowerCase();
+      if (lower === "all") return SUPPORTED_LEAGUES.slice();
+      if (SUPPORTED_LEAGUES.indexOf(lower) !== -1 && !seen[lower]) {
+        normalized.push(lower);
+        seen[lower] = true;
+      }
+    }
+    return normalized;
+  }
+
+  function expandMlbLeagueFamily(leagues) {
+    return Array.isArray(leagues) ? leagues.slice() : [];
+  }
+
+  function dateInRange(dateIso, fromIso, untilIso) {
+    if (!dateIso) return false;
+    if (fromIso && dateIso < fromIso) return false;
+    if (untilIso && dateIso > untilIso) return false;
+    return !!(fromIso || untilIso);
+  }
+
+  function boolOrDefault(value, fallback) {
+    return typeof value === "boolean" ? value : fallback;
+  }
+
+  function isNhlBreakWindow(dateIso, config) {
+    var cfg = config || {};
+    if (cfg.seasonalFiltering === false) return false;
+    if (cfg.hideNhlDuringOlympics === false) return false;
+    var from = cfg.hideNhlFrom || "2026-02-06";
+    var until = cfg.hideNhlUntil || "2026-02-24";
+    return dateInRange(dateIso, from, until);
+  }
+
+  function hideOlympicScoreboards(dateIso, config) {
+    var cfg = config || {};
+    if (cfg.seasonalFiltering === false) return false;
+    if (cfg.hideOlympicsAfterEnd === false) return false;
+    var from = cfg.hideOlympicsFrom || "2026-02-24";
+    return dateInRange(dateIso, from, cfg.hideOlympicsUntil || null);
+  }
+
+  function filterSeasonalLeagues(leagues, config, dateIso) {
+    if (!Array.isArray(leagues)) return [];
+    var cfg = config || {};
+    var todayIso = dateIso || cfg.todayIso || new Date().toLocaleDateString("en-CA", { timeZone: cfg.timeZone || "America/Chicago" });
+    var hideNhl = isNhlBreakWindow(todayIso, cfg);
+    var hideOlympics = hideOlympicScoreboards(todayIso, cfg);
+    return leagues.filter(function (league) {
+      if (hideNhl && league === "nhl") return false;
+      if (hideOlympics && (league === "olympic_mhockey" || league === "olympic_whockey")) return false;
+      return true;
+    });
+  }
+
+  function resolveConfiguredLeagues(config, dateIso) {
+    var cfg = config || {};
+    var source = (typeof cfg.leagues !== "undefined") ? cfg.leagues : cfg.league;
+    return filterSeasonalLeagues(expandMlbLeagueFamily(coerceLeagueArray(source)), cfg, dateIso);
+  }
+
+  return {
+    SUPPORTED_LEAGUES: SUPPORTED_LEAGUES,
+    normalizeLeagueKey: normalizeLeagueKey,
+    coerceLeagueArray: coerceLeagueArray,
+    expandMlbLeagueFamily: expandMlbLeagueFamily,
+    isNhlBreakWindow: isNhlBreakWindow,
+    hideOlympicScoreboards: hideOlympicScoreboards,
+    filterSeasonalLeagues: filterSeasonalLeagues,
+    resolveConfiguredLeagues: resolveConfiguredLeagues
+  };
+}));

--- a/test/league-config.test.js
+++ b/test/league-config.test.js
@@ -1,0 +1,23 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const leagueConfig = require('../shared-league-config');
+
+test('coerceLeagueArray handles all, arrays, commas, whitespace, and duplicates', () => {
+  assert.deepEqual(leagueConfig.coerceLeagueArray('mlb, nba nhl nba'), ['mlb', 'nba', 'nhl']);
+  assert.deepEqual(leagueConfig.coerceLeagueArray(['MLB', 'bad', ['nfl', 'nba']]), ['mlb', 'nfl', 'nba']);
+  assert.deepEqual(leagueConfig.coerceLeagueArray('all'), leagueConfig.SUPPORTED_LEAGUES);
+});
+
+test('seasonal filtering is configurable', () => {
+  assert.equal(leagueConfig.isNhlBreakWindow('2026-02-10', {}), true);
+  assert.equal(leagueConfig.isNhlBreakWindow('2026-02-10', { seasonalFiltering: false }), false);
+  assert.equal(leagueConfig.hideOlympicScoreboards('2026-02-25', {}), true);
+  assert.equal(leagueConfig.hideOlympicScoreboards('2026-02-25', { hideOlympicsAfterEnd: false }), false);
+});
+
+test('resolveConfiguredLeagues filters seasonal league windows', () => {
+  const cfg = { league: 'all', timeZone: 'UTC' };
+  assert.ok(!leagueConfig.resolveConfiguredLeagues(cfg, '2026-02-10').includes('nhl'));
+  assert.ok(!leagueConfig.resolveConfiguredLeagues(cfg, '2026-02-25').includes('olympic_mhockey'));
+  assert.ok(leagueConfig.resolveConfiguredLeagues({ league: 'all', seasonalFiltering: false }, '2026-02-25').includes('olympic_mhockey'));
+});


### PR DESCRIPTION
### Motivation
- Improve resilience when external providers are slow or fail by adding per-request timeouts and independent league fetches so one slow provider cannot block the rotation. 
- Centralize league/date/seasonal visibility logic to avoid duplication between helper and front-end and make seasonal rules configurable. 
- Surface provider/source status and stale/fallback indicators in the UI and provide offline asset diagnostics and unit tests.

### Description
- Add a shared configuration module `shared-league-config.js` and wire front-end `MMM-Scores.js` and helper `node_helper.js` to use its helpers (`normalizeLeagueKey`, `coerceLeagueArray`, seasonal filtering helpers, etc.).
- Refactor `node_helper.js` to introduce `_fetchResponse`, `_fetchJson`, and `_fetchText` with request timeouts (configurable via `requestTimeoutMs`) and to run league fetches in parallel using `Promise.allSettled`, plus a `last-good` cache and `_notifyGamesWithFallback` that sends stale/fallback payloads when providers fail (configurable TTL via `lastGoodCacheMs`).
- Replace many raw `fetch` usages with the new fetch helpers and parallelize MLB sportId requests to reduce latency; add error handling so failed fetches mark stale/fallback state and include `fetchedAt` metadata in `GAMES` payloads.
- Front-end changes in `MMM-Scores.js` add new configuration options (`requestTimeoutMs`, `lastGoodCacheMs`, seasonal filtering toggles, `showProviderStatus`), use the shared league config when available, and render a compact provider status line above scoreboards; styling added in `MMM-Scores.css`.
- Add `shared-league-config` unit tests in `test/league-config.test.js`, an asset checker script `scripts/check-assets.js`, and package scripts `test` and `check:assets` in `package.json`; update `README.md` to document new options and diagnostics.

### Testing
- Ran the new unit tests with `npm test` which executes `node --test test/*.test.js`, and the league-config tests completed successfully. 
- Ran the asset diagnostics `node scripts/check-assets.js` (exposed as `npm run check:assets`) to validate required font/logo folders and case-collision checks and it completed without critical failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bf79b5af0832284505a06ea9db24f)