### PR TITLE
Avoid caching failed scoreboard payloads

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -2272,7 +2272,7 @@ module.exports = NodeHelper.create({
       });
     }
 
-    if (!payload.isStale) {
+    if (!payload.isStale && !payload.errorMessage) {
       if (!this._lastGoodByLeague) this._lastGoodByLeague = {};
       this._lastGoodByLeague[normalizedLeague] = Object.assign({}, payload, {
         games: normalizedGames.slice(),

--- a/test/node-helper-cache.test.js
+++ b/test/node-helper-cache.test.js
@@ -1,0 +1,73 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+
+const originalLoad = Module._load;
+Module._load = function(request, parent, isMain) {
+  if (request === 'node_helper') {
+    return {
+      create(definition) {
+        return definition;
+      }
+    };
+  }
+  return originalLoad.apply(this, arguments);
+};
+
+let helperDefinition;
+try {
+  helperDefinition = require('../node_helper');
+} finally {
+  Module._load = originalLoad;
+}
+
+function createHelper() {
+  return Object.assign(Object.create(helperDefinition), {
+    config: {},
+    sent: [],
+    sendSocketNotification(notification, payload) {
+      this.sent.push({ notification, payload });
+    }
+  });
+}
+
+test('_notifyGames does not save error payloads as last good cache entries', () => {
+  const helper = createHelper();
+
+  helper._notifyGames('nfl', [], { errorMessage: 'provider unavailable' });
+
+  assert.equal(helper.sent.length, 1);
+  assert.equal(helper.sent[0].notification, 'GAMES');
+  assert.deepEqual(helper.sent[0].payload.games, []);
+  assert.equal(helper.sent[0].payload.errorMessage, 'provider unavailable');
+  assert.equal(helper._lastGoodByLeague, undefined);
+});
+
+test('_notifyGamesWithFallback without usable cache emits error without creating fallback cache', () => {
+  const helper = createHelper();
+  helper.config = { lastGoodCacheMs: 60_000 };
+
+  helper._notifyGamesWithFallback('nfl', [], { errorMessage: 'provider unavailable' });
+  helper._notifyGamesWithFallback('nfl', [], { errorMessage: 'still unavailable' });
+
+  assert.equal(helper.sent.length, 2);
+  assert.equal(helper.sent[0].payload.isStale, undefined);
+  assert.equal(helper.sent[0].payload.fallbackUsed, undefined);
+  assert.equal(helper.sent[1].payload.isStale, undefined);
+  assert.equal(helper.sent[1].payload.fallbackUsed, undefined);
+  assert.equal(helper._lastGoodByLeague, undefined);
+});
+
+test('_notifyGames caches successful responses for subsequent fallback use', () => {
+  const helper = createHelper();
+  helper.config = { lastGoodCacheMs: 60_000 };
+
+  helper._notifyGames('nfl', [{ id: 'game-1' }]);
+  helper._notifyGamesWithFallback('nfl', [], { errorMessage: 'provider unavailable' });
+
+  assert.equal(helper.sent.length, 2);
+  assert.deepEqual(helper.sent[1].payload.games, [{ id: 'game-1' }]);
+  assert.equal(helper.sent[1].payload.isStale, true);
+  assert.equal(helper.sent[1].payload.fallbackUsed, true);
+  assert.equal(helper.sent[1].payload.staleReason, 'provider unavailable');
+});


### PR DESCRIPTION
### Motivation
- Prevent transient provider failures from becoming the module’s "last good" cache entry which would cause subsequent fallbacks to reuse empty error payloads.
- Ensure the last-good cache only stores successful scoreboard responses so stale fallbacks remain meaningful.

### Description
- Change the `_notifyGames` condition to skip saving into `_lastGoodByLeague` when the payload contains `errorMessage` by updating the check to `if (!payload.isStale && !payload.errorMessage)` in `node_helper.js`.
- Add `test/node-helper-cache.test.js` with unit tests that simulate error payloads, repeated failures without cache, and successful responses being cached for fallback use.
- Preserve existing fallback behavior in `_notifyGamesWithFallback` so cached successful responses are still emitted with `isStale: true` and `fallbackUsed: true`.

### Testing
- Ran the test suite with `npm test` which executes the tests under `test/*.test.js` including the new `test/node-helper-cache.test.js` file.
- All tests passed (6 tests total) with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c453041248322a3e4cc604cf6e583)