### PR TITLE
Remove 'SO ' prefix from World Cup shootout superscripts

### DIFF
--- a/MMM-Scores.js
+++ b/MMM-Scores.js
@@ -2160,7 +2160,7 @@
           {
             value: goals,
             placeholder: "—",
-            superscript: (shootoutScore != null) ? ("SO " + shootoutScore) : (i === 0 ? awayShots : homeShots),
+            superscript: (shootoutScore != null) ? shootoutScore : (i === 0 ? awayShots : homeShots),
             superscriptClass: (shootoutScore != null) ? "shootout-superscript" : "shots-on-goal-superscript"
           }
         ];


### PR DESCRIPTION
### Motivation
- World Cup shootout/penalty goals were rendered with the literal `SO ` prefix (for example `SO 4`) in the scoreboard superscript, and the intent of this change is to show only the PK goal number as a superscript for a cleaner display.

### Description
- Update in `MMM-Scores.js` to set `superscript` to `shootoutScore` (the numeric PK value) when present for `league === "worldcup"` instead of `"SO " + shootoutScore`, leaving the fallback (shots-on-goal) behavior unchanged.

### Testing
- Ran `npm test` (module test suite) which passed all tests, and `node --check MMM-Scores.js` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4de3342fc08322ba787e9388e17a32)