### PR TITLE
Show World Cup final rounds as round scoreboards

### DIFF
--- a/MMM-Scores.css
+++ b/MMM-Scores.css
@@ -699,3 +699,13 @@
   letter-spacing: 0.08em;
   color: var(--scoreboard-muted);
 }
+
+.scoreboard-round-label {
+  width: min(100%, var(--scoreboard-content-width, 100%));
+  text-align: center;
+  font-size: calc(var(--scoreboard-label-font) + 2pt);
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--scoreboard-muted);
+  font-weight: 700;
+}

--- a/MMM-Scores.js
+++ b/MMM-Scores.js
@@ -1412,6 +1412,13 @@
       var providerStatus = this._buildProviderStatus();
       if (providerStatus) container.appendChild(providerStatus);
 
+      if (activeLeague === "worldcup" && this.currentExtras && this.currentExtras.worldCupRoundLabel) {
+        var roundLabel = document.createElement("div");
+        roundLabel.className = "scoreboard-round-label";
+        roundLabel.innerText = this.currentExtras.worldCupRoundLabel;
+        container.appendChild(roundLabel);
+      }
+
       var scoreboardPages = this._scoreboardPageCount || 0;
       var scoreboardRendered = false;
 

--- a/node_helper.js
+++ b/node_helper.js
@@ -1884,13 +1884,108 @@ module.exports = NodeHelper.create({
     return collected;
   },
 
+  _worldCupFinalRoundWindow(todayIso) {
+    const date = String(todayIso || "");
+    const windows = [
+      {
+        key: "quarterfinals",
+        label: "Quarterfinals",
+        fetchStartIso: "2026-07-08",
+        fetchEndIso: "2026-07-11",
+        displayStartIso: "2026-07-08",
+        displayEndIso: "2026-07-12"
+      },
+      {
+        key: "semifinals",
+        label: "Semifinals",
+        fetchStartIso: "2026-07-14",
+        fetchEndIso: "2026-07-15",
+        displayStartIso: "2026-07-13",
+        displayEndIso: "2026-07-16"
+      },
+      {
+        key: "finals",
+        label: "Finals",
+        fetchStartIso: "2026-07-18",
+        fetchEndIso: "2026-07-19",
+        displayStartIso: "2026-07-17",
+        displayEndIso: "2026-07-20"
+      }
+    ];
+
+    for (let i = 0; i < windows.length; i += 1) {
+      const window = windows[i];
+      if (date >= window.displayStartIso && date <= window.displayEndIso) return window;
+    }
+
+    return null;
+  },
+
+  _worldCupRoundDateCompact(window) {
+    if (!window) return null;
+    const start = String(window.fetchStartIso || "").replace(/-/g, "");
+    const end = String(window.fetchEndIso || "").replace(/-/g, "");
+    if (!start || !end) return null;
+    return start === end ? start : `${start}-${end}`;
+  },
+
+  _annotateWorldCupFinalRoundEvents(events, window) {
+    if (!Array.isArray(events) || !window) return events;
+    return events.map((event) => {
+      if (!event || typeof event !== "object") return event;
+      return Object.assign({}, event, { worldCupRoundLabel: window.label, worldCupRoundKey: window.key });
+    });
+  },
+
+  _worldCupFinalsDisplayWeight(event) {
+    const text = [
+      event && event.name,
+      event && event.shortName,
+      event && event.season && event.season.displayName,
+      event && event.competitions && event.competitions[0] && event.competitions[0].notes && event.competitions[0].notes[0] && event.competitions[0].notes[0].headline
+    ].filter(Boolean).join(" ").toLowerCase();
+
+    if (/third|3rd|third-place|3rd-place|bronze/.test(text)) return 1;
+    if (/final|championship/.test(text)) return 0;
+    return 0;
+  },
+
+  _orderWorldCupFinals(events, window) {
+    if (!Array.isArray(events) || !window || window.key !== "finals") return events;
+    return events.slice().sort((a, b) => {
+      const weightA = this._worldCupFinalsDisplayWeight(a);
+      const weightB = this._worldCupFinalsDisplayWeight(b);
+      if (weightA !== weightB) return weightA - weightB;
+
+      const dateA = this._firstDate(
+        a && a.date,
+        a && a.startDate,
+        a && a.startTimeUTC,
+        a && a.competitions && a.competitions[0] && (a.competitions[0].date || a.competitions[0].startDate || a.competitions[0].startTimeUTC)
+      );
+      const dateB = this._firstDate(
+        b && b.date,
+        b && b.startDate,
+        b && b.startTimeUTC,
+        b && b.competitions && b.competitions[0] && (b.competitions[0].date || b.competitions[0].startDate || b.competitions[0].startTimeUTC)
+      );
+
+      if (dateA && dateB) return dateB - dateA;
+      if (dateA) return -1;
+      if (dateB) return 1;
+      return 0;
+    });
+  },
+
   async _fetchWorldCupGames() {
     try {
       const context = this._getScoreboardDateContext();
+      const roundWindow = this._worldCupFinalRoundWindow(context.todayIso);
       const { dateIso, dateCompact } = context;
-      const url = `https://site.api.espn.com/apis/site/v2/sports/soccer/fifa.world/scoreboard?dates=${dateCompact}`;
+      const worldCupDates = this._worldCupRoundDateCompact(roundWindow) || dateCompact;
+      const url = `https://site.api.espn.com/apis/site/v2/sports/soccer/fifa.world/scoreboard?dates=${worldCupDates}`;
       const json = await this._fetchJson(url, {}, url);
-      const events = this._collectEspnScoreboardEvents(json);
+      const events = this._annotateWorldCupFinalRoundEvents(this._collectEspnScoreboardEvents(json), roundWindow);
 
       events.sort((a, b) => {
         const dateA = this._firstDate(
@@ -1913,7 +2008,7 @@ module.exports = NodeHelper.create({
       });
 
       let scheduleGames = [];
-      if (context.beforeUpdateCutoff) {
+      if (!roundWindow && context.beforeUpdateCutoff) {
         const scheduleUrl = `https://site.api.espn.com/apis/site/v2/sports/soccer/fifa.world/scoreboard?dates=${context.todayCompact}`;
         try {
           scheduleGames = this._collectEspnScoreboardEvents(await this._fetchJson(scheduleUrl, {}, scheduleUrl));
@@ -1921,9 +2016,15 @@ module.exports = NodeHelper.create({
           console.warn(`⚠️ Schedule fetch failed for ${context.todayIso}:`, scheduleError.message || scheduleError);
         }
       }
-      const displayEvents = context.beforeUpdateCutoff ? this._finalGamesOnly(events) : events;
-      console.log(`⚽ Sending ${displayEvents.length} World Cup games for ${dateIso} to front-end.`);
-      this._notifyGames("worldcup", displayEvents, { scheduleGames, showingPreviousFinals: context.beforeUpdateCutoff });
+      const roundEvents = this._orderWorldCupFinals(events, roundWindow);
+      const displayEvents = (!roundWindow && context.beforeUpdateCutoff) ? this._finalGamesOnly(roundEvents) : roundEvents;
+      const extras = { scheduleGames, showingPreviousFinals: !roundWindow && context.beforeUpdateCutoff };
+      if (roundWindow) {
+        extras.worldCupRoundKey = roundWindow.key;
+        extras.worldCupRoundLabel = roundWindow.label;
+      }
+      console.log(`⚽ Sending ${displayEvents.length} World Cup games for ${roundWindow ? worldCupDates : dateIso} to front-end.`);
+      this._notifyGames("worldcup", displayEvents, extras);
     } catch (e) {
       console.error("🚨 World Cup fetchGames failed:", e);
       this._notifyGamesWithFallback("worldcup", [], { errorMessage: e.message });


### PR DESCRIPTION
### Motivation

- Replace the day-based World Cup scoreboard with round-based views for the Quarterfinals, Semifinals, and Finals so the module shows the entire round while those stages are active. 
- Keep all Quarterfinals on screen until the day after the last quarterfinal finishes, then switch to Semifinals and after a day switch to Finals (including both the championship and 3rd-place games). 

### Description

- Added round window detection and helpers in `node_helper.js` (`_worldCupFinalRoundWindow`, `_worldCupRoundDateCompact`, `_annotateWorldCupFinalRoundEvents`) to detect Quarterfinals/Semifinals/Finals and annotate fetched events with `worldCupRoundKey` and `worldCupRoundLabel` extras.  
- Modified World Cup fetch logic in `node_helper.js` to request the full round date ranges when inside a round window, to avoid previous-day-only filtering during those windows, and to attach round metadata to the socket payload.  
- Added ordering helpers (`_worldCupFinalsDisplayWeight` and `_orderWorldCupFinals`) so the Finals screen places the championship match above the 3rd-place game. 
- Front-end changes in `MMM-Scores.js` render the round label below the module title when `currentExtras.worldCupRoundLabel` is present, and `MMM-Scores.css` adds `.scoreboard-round-label` styling. 

### Testing

- Ran a syntax check with `node -c node_helper.js` which completed successfully. 
- Ran the test suite with `npm test` (executes `node --test test/*.test.js`) and all tests passed (`6` tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4eb4223cac832298863598cdd34e3d)