### PR TITLE
Shorten World Cup kickoff times and preserve weekday prefix

### DIFF
--- a/MMM-Scores.js
+++ b/MMM-Scores.js
@@ -2069,7 +2069,8 @@
         statusText = "Suspended";
       } else if (isPreview) {
         var competitionDate = game && game.competitions && game.competitions[0] && game.competitions[0].date;
-        statusText = this._formatStartTime(game && (game.gameDate || game.startTimeUTC || game.date || competitionDate));
+        var startDate = game && (game.gameDate || game.startTimeUTC || game.date || competitionDate);
+        statusText = league === "worldcup" ? this._formatWorldCupStartTime(startDate) : this._formatStartTime(startDate);
       } else if (isFinal) {
         statusText = detailed || "Final";
       } else if (isLive) {
@@ -2689,6 +2690,46 @@
           hour: "numeric",
           minute: "2-digit"
         });
+        var gameDate = this._formatDateIsoForTimeZone(date, tz);
+        var today = this._todayIsoInTimeZone();
+        if (gameDate && today && gameDate !== today) {
+          var weekday = date.toLocaleDateString("en-US", {
+            timeZone: tz,
+            weekday: "short"
+          });
+          if (weekday) return weekday + " " + timeText;
+        }
+        return timeText;
+      } catch (e) {
+        return "";
+      }
+    },
+
+    _formatWorldCupStartTime: function (isoDate) {
+      if (!isoDate) return "";
+      try {
+        var date = new Date(isoDate);
+        if (isNaN(date.getTime())) return "";
+        var tz = this.config.timeZone || "America/Chicago";
+        var parts = date.toLocaleTimeString("en-US", {
+          timeZone: tz,
+          hour12: true,
+          hour: "numeric",
+          minute: "2-digit"
+        }).split(":");
+        var compactTime = date.toLocaleTimeString("en-US", {
+          timeZone: tz,
+          hour12: true,
+          hour: "numeric"
+        });
+        var timeText = (parts.length > 1 && parts[1].indexOf("00") !== 0)
+          ? date.toLocaleTimeString("en-US", {
+            timeZone: tz,
+            hour12: true,
+            hour: "numeric",
+            minute: "2-digit"
+          })
+          : compactTime;
         var gameDate = this._formatDateIsoForTimeZone(date, tz);
         var today = this._todayIsoInTimeZone();
         if (gameDate && today && gameDate !== today) {


### PR DESCRIPTION
### Motivation
- World Cup preview cards showed the day abbreviation before the gametime and that caused minute digits to be visually truncated, so whole-hour kickoffs should display as a compact hour (e.g., `6 PM`).
- Games not on the configured current date should still include the weekday prefix (for example, `Thu 6 PM`).

### Description
- Added a new helper `_formatWorldCupStartTime` that formats kickoff times compactly by preferring an hour-only `6 PM` style when minutes are `:00` and including minutes otherwise.
- Use the new `_formatWorldCupStartTime` for World Cup preview cards while leaving `_formatStartTime` unchanged for other leagues. 
- Preserve the existing behavior of prepending the short weekday when the game date differs from the current configured date. 
- All changes made in `MMM-Scores.js`.

### Testing
- Ran the module unit tests with `npm test` and all tests passed (`6` tests, `0` failures). 
- Verified syntax with `node -c MMM-Scores.js`, which returned without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4eb8aafc448322a418d99911b34255)