### PR TITLE
Fix hockey status clipping

### DIFF
--- a/MMM-Scores.css
+++ b/MMM-Scores.css
@@ -282,17 +282,32 @@
   overflow: hidden;
 }
 
+.scoreboard-card.league-nhl,
+.scoreboard-card.league-olympic_mhockey,
+.scoreboard-card.league-olympic_whockey {
+  overflow: visible;
+}
+
 .scoreboard-card.league-nhl .scoreboard-header,
 .scoreboard-card.league-olympic_mhockey .scoreboard-header,
 .scoreboard-card.league-olympic_whockey .scoreboard-header {
   position: relative;
+  z-index: 3;
+  overflow: visible;
+}
+
+.scoreboard-card.league-nhl .scoreboard-body,
+.scoreboard-card.league-olympic_mhockey .scoreboard-body,
+.scoreboard-card.league-olympic_whockey .scoreboard-body {
+  position: relative;
+  z-index: 1;
 }
 
 .scoreboard-card.league-nhl .scoreboard-status,
 .scoreboard-card.league-olympic_mhockey .scoreboard-status,
 .scoreboard-card.league-olympic_whockey .scoreboard-status {
   position: relative;
-  z-index: 1;
+  z-index: 4;
   flex-wrap: nowrap;
   white-space: nowrap;
   overflow: visible;


### PR DESCRIPTION
### Motivation

- Status text on NHL and Olympic hockey cards (e.g. times like `6 PM`) was being clipped by the card mask so the trailing `M` could be cut off.
- The goal is to allow the status/header to render above the black mask area while keeping the scoreboard body visually beneath it.

### Description

- Updated `MMM-Scores.css` to allow hockey cards to render outside the clipping area by setting `overflow: visible` on the hockey card selector. 
- Raised the header layer with `z-index: 3` and `overflow: visible` on the `.scoreboard-header` for NHL and Olympic hockey cards. 
- Added a positioned lower layer for the body (`position: relative; z-index: 1`) and elevated the `.scoreboard-status` to `z-index: 4` so status text renders above the mask.

### Testing

- Ran the module test suite with `npm test` and all automated tests passed (6 tests passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4eba12aa3c832291f39c7a29fd5dff)