### PR TITLE
World Cup: show dash placeholders for previews and compact meridiem display

### DIFF
--- a/MMM-Scores.css
+++ b/MMM-Scores.css
@@ -338,6 +338,12 @@
   color: var(--scoreboard-value-color);
 }
 
+.scoreboard-card.league-worldcup .scoreboard-status-meridiem {
+  font-size: 0.72em;
+  line-height: 1;
+  vertical-align: 0.18em;
+}
+
 .scoreboard-card .scoreboard-label {
   font-size: calc(var(--scoreboard-label-font) + 1pt);
   letter-spacing: 0.18em;

--- a/MMM-Scores.js
+++ b/MMM-Scores.js
@@ -1685,7 +1685,7 @@
 
       var statusEl = document.createElement("div");
       statusEl.className = "scoreboard-status" + (live ? " live" : "");
-      statusEl.textContent = (config && config.statusText) ? config.statusText : "";
+      this._setScoreboardStatusText(statusEl, (config && config.statusText) ? config.statusText : "", league);
       if (config && config.statusIndicator) {
         statusEl.appendChild(config.statusIndicator);
       }
@@ -2665,7 +2665,7 @@
         });
       }
 
-      if (!showVals && this._rowsContainValues(rows)) showVals = true;
+      if (!showVals && league !== "worldcup" && this._rowsContainValues(rows)) showVals = true;
 
       return this._createScoreboardCard({
         league: league,
@@ -2676,6 +2676,30 @@
         rows: rows,
         cardClasses: cardClasses
       });
+    },
+
+    _compactMeridiem: function (timeText) {
+      return (timeText || "").replace(/\s+([AP]M)$/i, "$1");
+    },
+
+    _setScoreboardStatusText: function (statusEl, statusText, league) {
+      var text = statusText || "";
+      if (league !== "worldcup") {
+        statusEl.textContent = text;
+        return;
+      }
+
+      var match = text.match(/^(.*?)([AP]M)$/i);
+      if (!match) {
+        statusEl.textContent = text;
+        return;
+      }
+
+      statusEl.textContent = match[1];
+      var meridiemEl = document.createElement("span");
+      meridiemEl.className = "scoreboard-status-meridiem";
+      meridiemEl.textContent = match[2].toUpperCase();
+      statusEl.appendChild(meridiemEl);
     },
 
     _formatStartTime: function (isoDate) {
@@ -2730,6 +2754,7 @@
             minute: "2-digit"
           })
           : compactTime;
+        timeText = this._compactMeridiem(timeText);
         var gameDate = this._formatDateIsoForTimeZone(date, tz);
         var today = this._todayIsoInTimeZone();
         if (gameDate && today && gameDate !== today) {


### PR DESCRIPTION
### Motivation
- World Cup games were showing upstream zero scores in preview mode instead of the intended dash placeholder, and the trailing `M` in `PM` could be clipped in the status line.

### Description
- Prevent automatic reveal of numeric values for World Cup preview cards by skipping the `_rowsContainValues` promotion for the `worldcup` league in the scoreboard row building logic in `MMM-Scores.js`.
- Introduce `_compactMeridiem(timeText)` to remove the space in `6 PM` → `6PM`, and use it when formatting World Cup kickoff times in `_formatWorldCupStartTime` in `MMM-Scores.js`.
- Add `_setScoreboardStatusText(statusEl, statusText, league)` in `MMM-Scores.js` to render World Cup `AM`/`PM` in a separate `<span>` so it can be styled independently and avoid clipping.
- Add CSS rules in `MMM-Scores.css` (`.scoreboard-card.league-worldcup .scoreboard-status-meridiem`) to reduce the meridiem font-size and adjust vertical alignment so the `PM` renders smaller and does not get cut off.

### Testing
- Ran a static syntax check with `node --check MMM-Scores.js`, which completed successfully.
- Ran the test suite with `npm test`, all tests passed (6/6 passing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ebd3d1c3c8322b418532eeaeaa8ee)