### PR TITLE
Show dashes for future World Cup scores

### DIFF
--- a/MMM-Scores.js
+++ b/MMM-Scores.js
@@ -2056,7 +2056,8 @@
 
       var isPostponed = /postponed/i.test(detailed);
       var isSuspended = /suspended/i.test(detailed);
-      var isPreview = state === "preview" || state === "pre" || state === "scheduled";
+      var isWarmup = /warm\s*up/i.test(detailed) || /warm\s*up/i.test(state);
+      var isPreview = !isWarmup && (state === "preview" || state === "pre" || state === "scheduled");
       var isFinal = state === "final" || state === "post" || !!statusType.completed || !!competitionStatusType.completed;
       var isLive = !isFinal && !isPreview && !isPostponed && !isSuspended;
 
@@ -2098,6 +2099,7 @@
       else if (isPreview) cardClasses.push("is-preview");
       else if (isPostponed) cardClasses.push("is-postponed");
       else if (isSuspended) cardClasses.push("is-suspended");
+      else if (isWarmup) cardClasses.push("is-warmup");
 
       var teams = (game && game.teams) || {};
       var away = teams.away || null;
@@ -2196,7 +2198,7 @@
         });
       }
 
-      if (!showVals && this._rowsContainValues(rows)) showVals = true;
+      if (!showVals && league !== "worldcup" && this._rowsContainValues(rows)) showVals = true;
 
       return this._createScoreboardCard({
         league: league,


### PR DESCRIPTION
### Motivation
- Upcoming World Cup games were showing `0-0` when providers supplied zero scores for future fixtures; the intent is to display placeholder dashes until warmups or gametime. 
- Warmup states should be visually distinct so scores can appear once teams are warming up or play begins.

### Description
- Detect `Warmup` by adding an `isWarmup` check (`/warm\s*up/i`) and exclude warmup from being treated as a preview in the NHL/World Cup scoreboard path. 
- Add an `is-warmup` card class so existing warmup styling can apply. 
- Preserve placeholder dashes for World Cup preview cards by preventing the automatic enabling of numeric value rendering for the `worldcup` league when rows contain numeric-looking values from the provider.

### Testing
- Ran the unit suite with `npm test` and all tests passed (`6` tests, `0` failures). 
- Ran `node --check MMM-Scores.js` to validate the modified file and it reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ec0b00b6c8322aab03c4dc2fc067e)