### PR TITLE
Compact meridiem display for status/time and preserve World Cup value behavior

### DIFF
--- a/MMM-Scores.css
+++ b/MMM-Scores.css
@@ -338,6 +338,12 @@
   color: var(--scoreboard-value-color);
 }
 
+.scoreboard-card .scoreboard-status-meridiem {
+  font-size: 0.72em;
+  line-height: 1;
+  vertical-align: 0.18em;
+}
+
 .scoreboard-card .scoreboard-label {
   font-size: calc(var(--scoreboard-label-font) + 1pt);
   letter-spacing: 0.18em;

--- a/MMM-Scores.js
+++ b/MMM-Scores.js
@@ -1685,7 +1685,7 @@
 
       var statusEl = document.createElement("div");
       statusEl.className = "scoreboard-status" + (live ? " live" : "");
-      statusEl.textContent = (config && config.statusText) ? config.statusText : "";
+      this._setScoreboardStatusText(statusEl, (config && config.statusText) ? config.statusText : "", league);
       if (config && config.statusIndicator) {
         statusEl.appendChild(config.statusIndicator);
       }
@@ -2665,7 +2665,7 @@
         });
       }
 
-      if (!showVals && this._rowsContainValues(rows)) showVals = true;
+      if (!showVals && league !== "worldcup" && this._rowsContainValues(rows)) showVals = true;
 
       return this._createScoreboardCard({
         league: league,
@@ -2676,6 +2676,25 @@
         rows: rows,
         cardClasses: cardClasses
       });
+    },
+
+    _compactMeridiem: function (timeText) {
+      return (timeText || "").replace(/\s+([AP]M)$/i, "$1");
+    },
+
+    _setScoreboardStatusText: function (statusEl, statusText, league) {
+      var text = statusText || "";
+      var match = text.match(/^(.*?)([AP]M)$/i);
+      if (!match) {
+        statusEl.textContent = text;
+        return;
+      }
+
+      statusEl.textContent = match[1];
+      var meridiemEl = document.createElement("span");
+      meridiemEl.className = "scoreboard-status-meridiem";
+      meridiemEl.textContent = match[2].toUpperCase();
+      statusEl.appendChild(meridiemEl);
     },
 
     _formatStartTime: function (isoDate) {
@@ -2690,6 +2709,7 @@
           hour: "numeric",
           minute: "2-digit"
         });
+        timeText = this._compactMeridiem(timeText);
         var gameDate = this._formatDateIsoForTimeZone(date, tz);
         var today = this._todayIsoInTimeZone();
         if (gameDate && today && gameDate !== today) {
@@ -2730,6 +2750,7 @@
             minute: "2-digit"
           })
           : compactTime;
+        timeText = this._compactMeridiem(timeText);
         var gameDate = this._formatDateIsoForTimeZone(date, tz);
         var today = this._todayIsoInTimeZone();
         if (gameDate && today && gameDate !== today) {
@@ -2761,12 +2782,12 @@
       try {
         var date = new Date(isoDate);
         if (isNaN(date.getTime())) return "";
-        return date.toLocaleTimeString("en-US", {
+        return this._compactMeridiem(date.toLocaleTimeString("en-US", {
           timeZone: this.config.timeZone || "America/Chicago",
           hour12: true,
           hour: "numeric",
           minute: "2-digit"
-        });
+        }));
       } catch (e) {
         return "";
       }


### PR DESCRIPTION
### Motivation

- Improve visual layout of AM/PM meridiem in scoreboard status and time strings by compacting and styling it separately.
- Ensure World Cup cards retain their previous behavior for showing metric values.

### Description

- Added CSS class `.scoreboard-status-meridiem` to style the meridiem portion of status text.
- Introduced `_compactMeridiem` helper to remove the space before `AM`/`PM` and `_setScoreboardStatusText` to split status text into main text and a styled meridiem `span`.
- Replaced direct `statusEl.textContent` assignment with a call to `_setScoreboardStatusText` when building the header.
- Applied `_compactMeridiem` to `_formatStartTime`, `_formatWorldCupStartTime`, and `_formatTimeOnly` so displayed times use the compact meridiem.
- Restored prior World Cup behavior by preventing automatic `showValues` enabling for the `worldcup` league with `if (!showVals && league !== "worldcup" && this._rowsContainValues(rows)) showVals = true;`.

### Testing

- Ran project linter with `npm run lint` and project unit tests with `npm test`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ebd3d1c3c8322b418532eeaeaa8ee)