### PR TITLE
Apply meridiem styling to all scoreboards

### DIFF
--- a/MMM-Scores.css
+++ b/MMM-Scores.css
@@ -338,7 +338,7 @@
   color: var(--scoreboard-value-color);
 }
 
-.scoreboard-card.league-worldcup .scoreboard-status-meridiem {
+.scoreboard-card .scoreboard-status-meridiem {
   font-size: 0.72em;
   line-height: 1;
   vertical-align: 0.18em;

--- a/MMM-Scores.js
+++ b/MMM-Scores.js
@@ -2686,12 +2686,7 @@
 
     _setScoreboardStatusText: function (statusEl, statusText, league) {
       var text = statusText || "";
-      if (league !== "worldcup") {
-        statusEl.textContent = text;
-        return;
-      }
-
-      var match = text.match(/^(.*?)([AP]M)$/i);
+      var match = text.match(/^(.*?\d(?::\d{2})?)\s*([AP]M)$/i);
       if (!match) {
         statusEl.textContent = text;
         return;


### PR DESCRIPTION
### Motivation
- Make AM/PM formatting consistent across all scoreboard cards by rendering the meridiem in the compact `scoreboard-status-meridiem` span for any start time that ends with AM/PM, not just World Cup cards.

### Description
- Generalize the meridiem extraction in `MMM-Scores.js` by updating `_setScoreboardStatusText` to detect a trailing time + meridiem via the regex and always split out the `AM/PM` into a dedicated span using `scoreboard-status-meridiem`.
- Broaden the CSS rule in `MMM-Scores.css` from `.scoreboard-card.league-worldcup .scoreboard-status-meridiem` to `.scoreboard-card .scoreboard-status-meridiem` so the smaller, raised meridiem styling applies to all leagues.
- No changes to tests or test harness code were required.

### Testing
- Ran `npm test` and the existing test suite passed (`6` tests, `0` failures). 
- Ran `node --check MMM-Scores.js` and the file passed the Node syntax check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ec35ae8888322aa926f5935379391)