### PR TITLE
Tighten World Cup round label spacing

### DIFF
--- a/MMM-Scores.css
+++ b/MMM-Scores.css
@@ -731,6 +731,10 @@
   font-weight: 700;
 }
 
+.games-layout.league-worldcup .scoreboard-round-label {
+  margin-bottom: calc(var(--matrix-gap) * -0.75);
+}
+
 .scoreboard-round-label-left {
   text-align: left;
 }


### PR DESCRIPTION
### Motivation
- Reduce excessive vertical space between the World Cup round label (e.g., "Quarterfinals") and the scoreboard grid so the label appears closer to the scorecards.

### Description
- Add a scoped CSS rule in `MMM-Scores.css` that targets `.games-layout.league-worldcup .scoreboard-round-label` and applies a negative bottom margin: `margin-bottom: calc(var(--matrix-gap) * -0.75);`.

### Testing
- Ran `npm test`, which executed the test suite and passed (6 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ec3e2b1448322838891c9e4c1b32e)