### PR TITLE
Add World Cup pregame score display option

### DIFF
--- a/MMM-Scores.css
+++ b/MMM-Scores.css
@@ -746,3 +746,8 @@
 .scoreboard-round-label-right {
   text-align: right;
 }
+
+.scoreboard-card.league-worldcup.is-preview .scoreboard-value.scoreboard-pregame-team-abbr {
+  font-size: var(--scoreboard-status-font);
+  line-height: 1.1;
+}

--- a/MMM-Scores.js
+++ b/MMM-Scores.js
@@ -290,6 +290,7 @@
       hideOlympicsAfterEnd:             true,
       hideOlympicsFrom:         "2026-02-24",
       showProviderStatus:              false,
+      worldCupPregameScoreDisplay:   "dash",
 
       // Width cap so it behaves in middle_center
       maxWidth:                      "800px"
@@ -1823,6 +1824,9 @@
             if (Object.prototype.hasOwnProperty.call(metric, "superscript")) {
               superscript = metric.superscript;
             }
+            if (Object.prototype.hasOwnProperty.call(metric, "placeholderClass") && metric.placeholderClass) {
+              valueEl.classList.add(metric.placeholderClass);
+            }
             var supClass = null;
             if (Object.prototype.hasOwnProperty.call(metric, "superscriptClass")) {
               supClass = metric.superscriptClass;
@@ -2179,10 +2183,12 @@
 
         var goals = this._firstNumber(entry.score, entry.goals, entry.team && entry.team.score);
         var shootoutScore = (league === "worldcup") ? this._extractSoccerShootoutScore(entry) : null;
+        var pregamePlaceholder = (league === "worldcup") ? this._worldCupPregameScorePlaceholder(abbr) : "—";
         var metrics = [
           {
             value: goals,
-            placeholder: "—",
+            placeholder: pregamePlaceholder.text,
+            placeholderClass: pregamePlaceholder.className,
             superscript: (shootoutScore != null) ? shootoutScore : (i === 0 ? awayShots : homeShots),
             superscriptClass: (shootoutScore != null) ? "shootout-superscript" : "shots-on-goal-superscript"
           }
@@ -2210,6 +2216,26 @@
         rows: rows,
         cardClasses: cardClasses
       });
+    },
+
+    _worldCupPregameScorePlaceholder: function (abbr) {
+      var display = this.config && this.config.worldCupPregameScoreDisplay;
+      if (this.currentExtras && this.currentExtras.worldCupPregameScoreDisplay) {
+        display = this.currentExtras.worldCupPregameScoreDisplay;
+      }
+
+      display = String(display || "dash").trim().toLowerCase();
+      if ((display === "abbr" || display === "abbreviation" || display === "team") && abbr) {
+        return {
+          text: abbr,
+          className: "scoreboard-pregame-team-abbr"
+        };
+      }
+
+      return {
+        text: "—",
+        className: ""
+      };
     },
 
     _createNflGameCard: function (game) {

--- a/MMM-Scores.js
+++ b/MMM-Scores.js
@@ -2183,7 +2183,7 @@
 
         var goals = this._firstNumber(entry.score, entry.goals, entry.team && entry.team.score);
         var shootoutScore = (league === "worldcup") ? this._extractSoccerShootoutScore(entry) : null;
-        var pregamePlaceholder = (league === "worldcup") ? this._worldCupPregameScorePlaceholder(abbr) : "—";
+        var pregamePlaceholder = (league === "worldcup") ? this._worldCupPregameScorePlaceholder(abbr) : { text: "—", className: "" };
         var metrics = [
           {
             value: goals,

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Every option may be declared globally, as an object keyed by league (`{ mlb: val
 | `hideOlympicsAfterEnd` | `boolean` | `true` | Hide Olympic hockey scoreboards after the configured Olympic end date. |
 | `hideOlympicsFrom` | `string` | `"2026-02-24"` | ISO date when Olympic hockey scoreboards are hidden unless seasonal filtering is disabled. |
 | `showProviderStatus` | `boolean` | `false` | Shows a compact source/updated/stale-data line above the scoreboards; stale fallback data is always indicated. |
+| `worldCupPregameScoreDisplay` | `string` | `"dash"` | Controls the World Cup pregame score placeholder. Use `"dash"` for the default dash or `"abbr"` to show each team abbreviation at the game-time font size. Can also be set in the module `.env` file with `MMM_SCORES_WORLDCUP_PREGAME_SCORE_DISPLAY=abbr`. |
 | `scoreboardColumns` | `number` | auto | Columns per page. Defaults to 2 for MLB (capped at 2) and 4 for NHL/NFL/NBA/World Cup/Olympic hockey. |
 | `gamesPerColumn` (`scoreboardRows`) | `number` | auto | Games stacked in each column (4 for all leagues unless overridden). |
 | `gamesPerPage` | `number` | derived | Override the total games per page; rows adjust automatically per league. |

--- a/node_helper.js
+++ b/node_helper.js
@@ -4,6 +4,8 @@ const dns        = require("dns");
 const cheerio    = require("cheerio");
 const http       = require("http");
 const https      = require("https");
+const fs         = require("fs");
+const path       = require("path");
 const { URL }    = require("url");
 const LeagueConfig = require("./shared-league-config");
 
@@ -111,6 +113,63 @@ function createHttpFetchFallback(maxRedirects = 5) {
   return (url, options) => requestOnce(url, options, maxRedirects);
 }
 
+
+function parseEnvBoolean(value) {
+  if (value == null) return null;
+  const normalized = String(value).trim().toLowerCase();
+  if (["1", "true", "yes", "y", "on"].indexOf(normalized) !== -1) return true;
+  if (["0", "false", "no", "n", "off"].indexOf(normalized) !== -1) return false;
+  return null;
+}
+
+function parseLocalEnvFile(filePath) {
+  const values = {};
+  let text = "";
+  try {
+    text = fs.readFileSync(filePath, "utf8");
+  } catch (error) {
+    if (error && error.code !== "ENOENT") {
+      console.warn(`⚠️ MMM-Scores could not read ${filePath}: ${error.message}`);
+    }
+    return values;
+  }
+
+  text.split(/\r?\n/).forEach((line) => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.charAt(0) === "#") return;
+
+    const match = trimmed.match(/^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/);
+    if (!match) return;
+
+    let value = match[2].trim();
+    const quote = value.charAt(0);
+    if ((quote === '"' || quote === "'") && value.charAt(value.length - 1) === quote) {
+      value = value.slice(1, -1);
+    }
+    values[match[1]] = value;
+  });
+
+  return values;
+}
+
+function loadEnvConfigOverrides() {
+  const fileValues = parseLocalEnvFile(path.join(__dirname, ".env"));
+  const env = Object.assign({}, fileValues, process.env || {});
+  const overrides = {};
+
+  const display = env.MMM_SCORES_WORLDCUP_PREGAME_SCORE_DISPLAY || env.WORLDCUP_PREGAME_SCORE_DISPLAY;
+  if (display != null && String(display).trim()) {
+    overrides.worldCupPregameScoreDisplay = String(display).trim().toLowerCase();
+  }
+
+  const showAbbr = parseEnvBoolean(env.MMM_SCORES_WORLDCUP_PREGAME_SCORE_ABBR || env.WORLDCUP_PREGAME_SCORE_ABBR);
+  if (showAbbr !== null) {
+    overrides.worldCupPregameScoreDisplay = showAbbr ? "abbr" : "dash";
+  }
+
+  return overrides;
+}
+
 const fetch = (typeof global.fetch === "function")
   ? global.fetch.bind(global)
   : createHttpFetchFallback();
@@ -189,7 +248,7 @@ module.exports = NodeHelper.create({
 
   socketNotificationReceived(notification, payload) {
     if (notification === "INIT") {
-      this.config = payload || {};
+      this.config = Object.assign({}, payload || {}, loadEnvConfigOverrides());
       this.leagues = this._resolveConfiguredLeagues();
       if (!Array.isArray(this.leagues) || this.leagues.length === 0) {
         this.leagues = [this._getLeague()];
@@ -2366,6 +2425,10 @@ module.exports = NodeHelper.create({
       games: normalizedGames,
       fetchedAt: new Date().toISOString()
     };
+
+    if (normalizedLeague === "worldcup" && this.config && this.config.worldCupPregameScoreDisplay) {
+      payload.worldCupPregameScoreDisplay = this.config.worldCupPregameScoreDisplay;
+    }
 
     if (extras && typeof extras === "object") {
       Object.keys(extras).forEach((key) => {


### PR DESCRIPTION
### Motivation
- Provide a configuration and `.env` override so World Cup pregame score placeholders can show a dash or the team 3-letter abbreviation. 
- Allow the abbreviation display to match the game-time/status font size for better visual parity with live/preview states.

### Description
- Added a new default config `worldCupPregameScoreDisplay` with value `"dash"` in `MMM-Scores.js` and a front-end helper method `_worldCupPregameScorePlaceholder` to choose the placeholder text and CSS class. 
- Front-end rendering now applies an optional `placeholderClass` so pregame abbreviation placeholders get the `scoreboard-pregame-team-abbr` class and are styled to the `--scoreboard-status-font` size in `MMM-Scores.css`. 
- The helper (`node_helper.js`) now reads a local `.env` file and process environment for `MMM_SCORES_WORLDCUP_PREGAME_SCORE_DISPLAY` (and a boolean alias `MMM_SCORES_WORLDCUP_PREGAME_SCORE_ABBR`) via `loadEnvConfigOverrides`, merges those overrides into the module config, and passes the resolved `worldCupPregameScoreDisplay` through the `GAMES` payload for the front end to consume. 
- Documentation updated in `README.md` to document `worldCupPregameScoreDisplay` and the `.env` variable `MMM_SCORES_WORLDCUP_PREGAME_SCORE_DISPLAY`.

### Testing
- Ran syntax checks `node --check MMM-Scores.js` and `node --check node_helper.js`, which passed. 
- Ran unit tests with `npm test` (6 tests), and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ec58ed80483228468669fc03d5ec3)