### PR TITLE
Order World Cup knockout scoreboard by next game

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -1966,6 +1966,12 @@ module.exports = NodeHelper.create({
       const finalB = this._isFinalGame(b);
       if (finalA !== finalB) return finalA ? 1 : -1;
 
+      if (window.key === "finals" && finalA && finalB) {
+        const weightA = this._worldCupFinalsDisplayWeight(a);
+        const weightB = this._worldCupFinalsDisplayWeight(b);
+        if (weightA !== weightB) return weightA - weightB;
+      }
+
       const dateA = this._worldCupEventDate(a);
       const dateB = this._worldCupEventDate(b);
       if (dateA && dateB) return dateA - dateB;

--- a/node_helper.js
+++ b/node_helper.js
@@ -1950,29 +1950,34 @@ module.exports = NodeHelper.create({
     return 0;
   },
 
-  _orderWorldCupFinals(events, window) {
-    if (!Array.isArray(events) || !window || window.key !== "finals") return events;
+  _worldCupEventDate(event) {
+    return this._firstDate(
+      event && event.date,
+      event && event.startDate,
+      event && event.startTimeUTC,
+      event && event.competitions && event.competitions[0] && (event.competitions[0].date || event.competitions[0].startDate || event.competitions[0].startTimeUTC)
+    );
+  },
+
+  _orderWorldCupFinalRoundEvents(events, window) {
+    if (!Array.isArray(events) || !window || !/^(quarterfinals|semifinals|finals)$/.test(window.key || "")) return events;
     return events.slice().sort((a, b) => {
-      const weightA = this._worldCupFinalsDisplayWeight(a);
-      const weightB = this._worldCupFinalsDisplayWeight(b);
-      if (weightA !== weightB) return weightA - weightB;
+      const finalA = this._isFinalGame(a);
+      const finalB = this._isFinalGame(b);
+      if (finalA !== finalB) return finalA ? 1 : -1;
 
-      const dateA = this._firstDate(
-        a && a.date,
-        a && a.startDate,
-        a && a.startTimeUTC,
-        a && a.competitions && a.competitions[0] && (a.competitions[0].date || a.competitions[0].startDate || a.competitions[0].startTimeUTC)
-      );
-      const dateB = this._firstDate(
-        b && b.date,
-        b && b.startDate,
-        b && b.startTimeUTC,
-        b && b.competitions && b.competitions[0] && (b.competitions[0].date || b.competitions[0].startDate || b.competitions[0].startTimeUTC)
-      );
-
-      if (dateA && dateB) return dateB - dateA;
+      const dateA = this._worldCupEventDate(a);
+      const dateB = this._worldCupEventDate(b);
+      if (dateA && dateB) return dateA - dateB;
       if (dateA) return -1;
       if (dateB) return 1;
+
+      if (window.key === "finals") {
+        const weightA = this._worldCupFinalsDisplayWeight(a);
+        const weightB = this._worldCupFinalsDisplayWeight(b);
+        if (weightA !== weightB) return weightA - weightB;
+      }
+
       return 0;
     });
   },
@@ -2016,7 +2021,7 @@ module.exports = NodeHelper.create({
           console.warn(`⚠️ Schedule fetch failed for ${context.todayIso}:`, scheduleError.message || scheduleError);
         }
       }
-      const roundEvents = this._orderWorldCupFinals(events, roundWindow);
+      const roundEvents = this._orderWorldCupFinalRoundEvents(events, roundWindow);
       const displayEvents = (!roundWindow && context.beforeUpdateCutoff) ? this._finalGamesOnly(roundEvents) : roundEvents;
       const extras = { scheduleGames, showingPreviousFinals: !roundWindow && context.beforeUpdateCutoff };
       if (roundWindow) {

--- a/test/world-cup-order.test.js
+++ b/test/world-cup-order.test.js
@@ -25,10 +25,11 @@ function createHelper() {
   return Object.assign(Object.create(helperDefinition), { config: {} });
 }
 
-function event(id, date, state = 'pre') {
+function event(id, date, state = 'pre', name) {
   const completed = state === 'post';
   return {
     id,
+    name: name || id,
     date,
     competitions: [{ date }],
     status: {
@@ -63,4 +64,14 @@ test('World Cup finals round orders third-place and championship games by schedu
   ], { key: 'finals' });
 
   assert.deepEqual(ordered.map((game) => game.id), ['third-place', 'championship']);
+});
+
+test('World Cup completed finals keep championship above third-place game', () => {
+  const helper = createHelper();
+  const ordered = helper._orderWorldCupFinalRoundEvents([
+    event('third-place', '2026-07-18T19:00:00Z', 'post', 'Third Place'),
+    event('championship', '2026-07-19T19:00:00Z', 'post', 'Final')
+  ], { key: 'finals' });
+
+  assert.deepEqual(ordered.map((game) => game.id), ['championship', 'third-place']);
 });

--- a/test/world-cup-order.test.js
+++ b/test/world-cup-order.test.js
@@ -1,0 +1,66 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+
+const originalLoad = Module._load;
+Module._load = function(request, parent, isMain) {
+  if (request === 'node_helper') {
+    return {
+      create(definition) {
+        return definition;
+      }
+    };
+  }
+  return originalLoad.apply(this, arguments);
+};
+
+let helperDefinition;
+try {
+  helperDefinition = require('../node_helper');
+} finally {
+  Module._load = originalLoad;
+}
+
+function createHelper() {
+  return Object.assign(Object.create(helperDefinition), { config: {} });
+}
+
+function event(id, date, state = 'pre') {
+  const completed = state === 'post';
+  return {
+    id,
+    date,
+    competitions: [{ date }],
+    status: {
+      abstractGameState: completed ? 'Final' : (state === 'in' ? 'Live' : 'Preview'),
+      type: { state, completed }
+    }
+  };
+}
+
+test('World Cup quarterfinal round puts the next unfinished game first and finals last', () => {
+  const helper = createHelper();
+  const ordered = helper._orderWorldCupFinalRoundEvents([
+    event('completed-early', '2026-07-08T19:00:00Z', 'post'),
+    event('next', '2026-07-10T19:00:00Z', 'pre'),
+    event('later', '2026-07-11T19:00:00Z', 'pre'),
+    event('completed-late', '2026-07-09T19:00:00Z', 'post')
+  ], { key: 'quarterfinals' });
+
+  assert.deepEqual(ordered.map((game) => game.id), [
+    'next',
+    'later',
+    'completed-early',
+    'completed-late'
+  ]);
+});
+
+test('World Cup finals round orders third-place and championship games by schedule until completed', () => {
+  const helper = createHelper();
+  const ordered = helper._orderWorldCupFinalRoundEvents([
+    event('championship', '2026-07-19T19:00:00Z', 'pre'),
+    event('third-place', '2026-07-18T19:00:00Z', 'pre')
+  ], { key: 'finals' });
+
+  assert.deepEqual(ordered.map((game) => game.id), ['third-place', 'championship']);
+});


### PR DESCRIPTION
### Motivation
- Ensure World Cup knockout-round scoreboards (quarterfinals, semifinals, finals) surface the next unfinished match at the top and move completed games to the bottom for clearer live viewing.

### Description
- Added a helper ` _worldCupEventDate` to reliably extract an event's start timestamp from ESPN event objects.
- Introduced `_orderWorldCupFinalRoundEvents` which groups unfinished games before completed games, sorts unfinished games by scheduled start time ascending, and falls back to the existing finals weight (`_worldCupFinalsDisplayWeight`) when dates are unavailable.
- Replaced the previous finals-only ordering call with the new round-aware ordering in `_fetchWorldCupGames` so annotated round events are ordered prior to sending to the front end.
- Added `test/world-cup-order.test.js` containing `node:test` cases that validate quarterfinal ordering (next unfinished first, completed games last) and finals scheduling order.

### Testing
- Ran `npm test` which executed the full test suite including the new `world-cup-order.test.js`; all tests passed (8 tests, 0 failures).
- No other automated test changes were made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51050dcc588322bea499d80e0b0040)