### PR TITLE
Handle MLB All-Star team names as AL/NL and add tests

### DIFF
--- a/MMM-Scores.js
+++ b/MMM-Scores.js
@@ -27,6 +27,21 @@
     "vs": true
   };
 
+  var MLB_ALL_STAR_ABBREVIATIONS_BY_NAME = {
+    "al": "AL",
+    "al all-stars": "AL",
+    "al all stars": "AL",
+    "american league": "AL",
+    "american league all-stars": "AL",
+    "american league all stars": "AL",
+    "nl": "NL",
+    "nl all-stars": "NL",
+    "nl all stars": "NL",
+    "national league": "NL",
+    "national league all-stars": "NL",
+    "national league all stars": "NL"
+  };
+
   var MLB_INTERNATIONAL_ABBREVIATIONS_BY_TEAM_ID = {
     784: "CAN",
     792: "COL",
@@ -2926,11 +2941,13 @@
           || team.clubName
           || ""
         ).trim().toLowerCase();
+        var allStarAbbr = MLB_ALL_STAR_ABBREVIATIONS_BY_NAME[mlbCountryName] || "";
         var intlCountryAbbr = MLB_INTERNATIONAL_ABBREVIATIONS_BY_COUNTRY_NAME[mlbCountryName] || "";
         var intlAbbr = Number.isFinite(teamId)
           ? MLB_INTERNATIONAL_ABBREVIATIONS_BY_TEAM_ID[teamId]
           : "";
-        abbr = intlAbbr
+        abbr = allStarAbbr
+          || intlAbbr
           || intlCountryAbbr
           || MLB_ABBREVIATIONS[name]
           || team.abbreviation

--- a/test/mlb-all-star-abbreviations.test.js
+++ b/test/mlb-all-star-abbreviations.test.js
@@ -1,0 +1,42 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+function createModuleDefinition() {
+  let definition;
+  const source = fs.readFileSync(path.join(__dirname, '..', 'MMM-Scores.js'), 'utf8');
+  const context = {
+    Module: {
+      register(_name, moduleDefinition) {
+        definition = moduleDefinition;
+      }
+    }
+  };
+
+  vm.runInNewContext(source, context, { filename: 'MMM-Scores.js' });
+  return definition;
+}
+
+test('MLB All-Star teams render as AL and NL abbreviations', () => {
+  const moduleDefinition = createModuleDefinition();
+
+  assert.equal(moduleDefinition._abbrForTeam({ displayName: 'American League All-Stars' }, 'mlb'), 'AL');
+  assert.equal(moduleDefinition._abbrForTeam({ displayName: 'National League All-Stars' }, 'mlb'), 'NL');
+});
+
+test('MLB All-Star abbreviations use dedicated AL and NL logo files', () => {
+  const moduleDefinition = createModuleDefinition();
+  const moduleInstance = Object.assign(Object.create(moduleDefinition), {
+    _getLeague() {
+      return 'mlb';
+    },
+    file(relativePath) {
+      return relativePath;
+    }
+  });
+
+  assert.equal(moduleInstance.getLogoUrl('AL'), 'images/mlb/AL.png');
+  assert.equal(moduleInstance.getLogoUrl('NL'), 'images/mlb/NL.png');
+});


### PR DESCRIPTION
### Motivation
- Ensure All-Star team display names like `American League All-Stars` and `National League All-Stars` resolve to the conventional `AL` and `NL` abbreviations so they show the correct logos and labels.

### Description
- Add `MLB_ALL_STAR_ABBREVIATIONS_BY_NAME` mapping to normalize various All-Star team name variants to `AL` or `NL`.
- Update `_abbrForTeam` to check the All-Star name mapping before falling back to international/team abbreviation logic so All-Star entries return the correct short code.
- Add `test/mlb-all-star-abbreviations.test.js` unit tests that verify abbreviation resolution for All-Star team names and that `getLogoUrl('AL')` and `getLogoUrl('NL')` return the expected file paths.

### Testing
- Run the new unit tests with `node test/mlb-all-star-abbreviations.test.js` and the assertions for abbreviation mapping and logo URL lookup passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56614591888322845ad62080e0812c)