### PR TITLE
Ensure MLB All-Star logo assets are verified

### DIFF
--- a/scripts/check-assets.js
+++ b/scripts/check-assets.js
@@ -22,6 +22,15 @@ for (const rel of requiredPaths) {
   check(fs.existsSync(path.join(ROOT, rel)), `${rel} exists`);
 }
 
+const requiredAssets = [
+  'images/mlb/AL.png',
+  'images/mlb/NL.png'
+];
+
+for (const rel of requiredAssets) {
+  check(fs.existsSync(path.join(ROOT, rel)), `${rel} exists`);
+}
+
 const dirs = ['images/mlb', 'images/nhl', 'images/nfl', 'images/nba', 'images/oly'];
 for (const rel of dirs) {
   const dir = path.join(ROOT, rel);

--- a/test/mlb-all-star-abbreviations.test.js
+++ b/test/mlb-all-star-abbreviations.test.js
@@ -26,7 +26,7 @@ test('MLB All-Star teams render as AL and NL abbreviations', () => {
   assert.equal(moduleDefinition._abbrForTeam({ displayName: 'National League All-Stars' }, 'mlb'), 'NL');
 });
 
-test('MLB All-Star abbreviations use dedicated AL and NL logo files', () => {
+test('MLB All-Star abbreviations use existing dedicated AL and NL logo files', () => {
   const moduleDefinition = createModuleDefinition();
   const moduleInstance = Object.assign(Object.create(moduleDefinition), {
     _getLeague() {
@@ -37,6 +37,11 @@ test('MLB All-Star abbreviations use dedicated AL and NL logo files', () => {
     }
   });
 
-  assert.equal(moduleInstance.getLogoUrl('AL'), 'images/mlb/AL.png');
-  assert.equal(moduleInstance.getLogoUrl('NL'), 'images/mlb/NL.png');
+  const alLogoPath = moduleInstance.getLogoUrl('AL');
+  const nlLogoPath = moduleInstance.getLogoUrl('NL');
+
+  assert.equal(alLogoPath, 'images/mlb/AL.png');
+  assert.equal(nlLogoPath, 'images/mlb/NL.png');
+  assert.ok(fs.existsSync(path.join(__dirname, '..', alLogoPath)), `${alLogoPath} should exist`);
+  assert.ok(fs.existsSync(path.join(__dirname, '..', nlLogoPath)), `${nlLogoPath} should exist`);
 });


### PR DESCRIPTION
### Motivation
- Tests called `getLogoUrl('AL')`/`getLogoUrl('NL')` but the repo previously did not assert the corresponding `images/mlb/AL.png` and `images/mlb/NL.png` files exist, allowing missing logos to go unnoticed and the UI to hide them at runtime.
- Add explicit checks so missing All-Star logo assets are detected by automated checks and tests fail fast if assets are absent.

### Description
- Updated `test/mlb-all-star-abbreviations.test.js` to rename the test to `use existing dedicated AL and NL logo files` and to assert that the resolved `images/mlb/AL.png` and `images/mlb/NL.png` paths exist on disk using `fs.existsSync`.
- Updated `scripts/check-assets.js` to require `images/mlb/AL.png` and `images/mlb/NL.png` by adding a `requiredAssets` list and checking each path with the existing `check` helper.
- Kept existing behavior of `getLogoUrl` unchanged; tests now validate both the returned path and file presence.

### Testing
- Ran `npm test`, which executed the test suite and all tests passed (11 tests, 0 failures). 
- Ran `npm run check:assets`, which reported the required asset checks (including `images/mlb/AL.png` and `images/mlb/NL.png`) as present and completed with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5664e283288322a6dcd3c241ba2b55)