### PR TITLE
Paginate next-day schedule games

### DIFF
--- a/MMM-Scores.js
+++ b/MMM-Scores.js
@@ -633,7 +633,9 @@
       var scheduleGames = (this.scheduleGamesByLeague && Array.isArray(this.scheduleGamesByLeague[league]))
         ? this.scheduleGamesByLeague[league]
         : [];
-      var schedulePages = scheduleGames.length > 0 ? 1 : 0;
+      var schedulePages = (scheduleGames.length > 0)
+        ? Math.ceil(scheduleGames.length / this._gamesPerPage)
+        : 0;
 
       var totalPages = scoreboardPages + schedulePages;
       if (totalPages === 0) totalPages = 1;
@@ -1459,9 +1461,11 @@
       if (scoreboardPages > 0 && this.currentScreen < scoreboardPages) {
         var start = this.currentScreen * this._gamesPerPage;
         pageGames = this.games.slice(start, start + this._gamesPerPage);
-      } else if (scheduleGamesForLeague.length > 0 && this.currentScreen === scoreboardPages) {
-        pageGames = scheduleGamesForLeague.slice(0, this._gamesPerPage);
-        isSchedulePage = true;
+      } else if (scheduleGamesForLeague.length > 0 && this.currentScreen >= scoreboardPages) {
+        var schedulePageIndex = this.currentScreen - scoreboardPages;
+        var scheduleStart = schedulePageIndex * this._gamesPerPage;
+        pageGames = scheduleGamesForLeague.slice(scheduleStart, scheduleStart + this._gamesPerPage);
+        isSchedulePage = pageGames.length > 0;
       }
 
       if (pageGames && pageGames.length > 0) {

--- a/test/schedule-pagination.test.js
+++ b/test/schedule-pagination.test.js
@@ -1,0 +1,68 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+function createModuleDefinition() {
+  let definition;
+  const source = fs.readFileSync(path.join(__dirname, '..', 'MMM-Scores.js'), 'utf8');
+  const context = {
+    Module: {
+      register(_name, moduleDefinition) {
+        definition = moduleDefinition;
+      }
+    }
+  };
+
+  vm.runInNewContext(source, context, { filename: 'MMM-Scores.js' });
+  return definition;
+}
+
+function createModuleInstance(overrides = {}) {
+  const definition = createModuleDefinition();
+  return Object.assign(Object.create(definition), {
+    config: Object.assign({}, definition.defaults, overrides.config || {}),
+    gamesByLeague: overrides.gamesByLeague || {},
+    scheduleGamesByLeague: overrides.scheduleGamesByLeague || {},
+    loadedLeagues: { nba: true },
+    extrasByLeague: {},
+    _leagueRotation: ['nba'],
+    _activeLeagueIndex: 0,
+    currentScreen: overrides.currentScreen || 0,
+    totalGamePages: 1,
+    _scoreboardPageCount: 0,
+    _layoutScale: 1
+  });
+}
+
+test('next-day schedule games are counted across all scoreboard pages', () => {
+  const scheduleGames = Array.from({ length: 17 }, (_, index) => ({ id: `schedule-${index}` }));
+  const instance = createModuleInstance({
+    config: { scoreboardColumns: 4, gamesPerColumn: 4 },
+    gamesByLeague: { nba: [] },
+    scheduleGamesByLeague: { nba: scheduleGames }
+  });
+
+  instance._applyActiveLeagueState();
+
+  assert.equal(instance._gamesPerPage, 16);
+  assert.equal(instance._scoreboardPageCount, 0);
+  assert.equal(instance.totalGamePages, 2);
+});
+
+test('schedule pagination is added after current scoreboard pages', () => {
+  const scoreGames = Array.from({ length: 17 }, (_, index) => ({ id: `score-${index}` }));
+  const scheduleGames = Array.from({ length: 33 }, (_, index) => ({ id: `schedule-${index}` }));
+  const instance = createModuleInstance({
+    config: { scoreboardColumns: 4, gamesPerColumn: 4 },
+    gamesByLeague: { nba: scoreGames },
+    scheduleGamesByLeague: { nba: scheduleGames }
+  });
+
+  instance._applyActiveLeagueState();
+
+  assert.equal(instance._gamesPerPage, 16);
+  assert.equal(instance._scoreboardPageCount, 2);
+  assert.equal(instance.totalGamePages, 5);
+});


### PR DESCRIPTION
### Motivation

- The scoreboard only ever showed the first page of next-day (schedule) games instead of allowing scheduled games to span multiple rotation pages, preventing some upcoming games from appearing.

### Description

- Count schedule pages by computing `Math.ceil(scheduleGames.length / this._gamesPerPage)` instead of forcing schedule games into a single page in `_applyActiveLeagueState`.
- When rendering, slice the appropriate schedule subset for the active schedule page by using `schedulePageIndex = this.currentScreen - scoreboardPages` and `scheduleStart = schedulePageIndex * this._gamesPerPage` so each schedule page shows the correct games in `_buildGames`.
- Only mark a page as a schedule page when the sliced `pageGames` contains items and keep `totalGamePages` as `scoreboardPages + schedulePages` so rotation/league advancement remains consistent.
- Add `test/schedule-pagination.test.js` with unit tests that cover schedule-only pagination and mixed scoreboard + schedule pagination scenarios.

### Testing

- Ran the full test suite with `npm test` which executes `node --test test/*.test.js`, and all tests passed (13 tests, 0 failures). 
- The new `test/schedule-pagination.test.js` tests were executed and succeeded, validating both schedule-only and mixed pagination behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a63bd9fbc888322832b9d4ce6540080)