### PR TITLE
Handle partial MLB feed failures gracefully

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/node_helper.js
+++ b/node_helper.js
@@ -294,15 +294,15 @@ module.exports = NodeHelper.create({
       const gamesByPk = new Map();
       const scheduleByPk = new Map();
 
-      const displayResults = await Promise.all(MLB_SCOREBOARD_SPORT_IDS.map((sportId) => this._fetchMlbGamesBySport(dateIso, sportId)));
-      displayResults.flat().forEach((game) => {
+      const displayGamesFlat = await this._fetchMlbGamesForDate(dateIso);
+      displayGamesFlat.forEach((game) => {
         const gamePk = Number(game && game.gamePk);
         if (Number.isFinite(gamePk)) gamesByPk.set(gamePk, game);
       });
 
       if (context.beforeUpdateCutoff) {
-        const scheduleResults = await Promise.all(MLB_SCOREBOARD_SPORT_IDS.map((sportId) => this._fetchMlbGamesBySport(context.todayIso, sportId)));
-        scheduleResults.flat().forEach((game) => {
+        const scheduleGamesFlat = await this._fetchMlbGamesForDate(context.todayIso);
+        scheduleGamesFlat.forEach((game) => {
           const gamePk = Number(game && game.gamePk);
           if (Number.isFinite(gamePk)) scheduleByPk.set(gamePk, game);
         });
@@ -369,6 +369,31 @@ module.exports = NodeHelper.create({
         games.push(dateBucket.games[j]);
       }
     }
+
+    return games;
+  },
+
+  // Fetches every configured MLB sportId independently so that a failure on
+  // one feed (e.g. the international/WBC sportId, which is far more prone to
+  // empty or erroring responses) never wipes out a successful fetch of the
+  // primary MLB sportId. Only a failure of the primary sportId is fatal.
+  async _fetchMlbGamesForDate(dateIso) {
+    const primarySportId = MLB_SCOREBOARD_SPORT_IDS[0];
+    const settled = await Promise.allSettled(
+      MLB_SCOREBOARD_SPORT_IDS.map((sportId) => this._fetchMlbGamesBySport(dateIso, sportId))
+    );
+
+    const games = [];
+    settled.forEach((result, index) => {
+      const sportId = MLB_SCOREBOARD_SPORT_IDS[index];
+      if (result.status === "fulfilled") {
+        games.push(...result.value);
+        return;
+      }
+
+      console.warn(`⚠️ MLB sportId=${sportId} fetch failed for ${dateIso}:`, result.reason && result.reason.message);
+      if (sportId === primarySportId) throw result.reason;
+    });
 
     return games;
   },

--- a/test/mlb-partial-feed-failure.test.js
+++ b/test/mlb-partial-feed-failure.test.js
@@ -1,0 +1,99 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+
+// node_helper.js binds `fetch` to global.fetch at require time, so the stub
+// must be installed before requiring it, and stay in place for the life of
+// the process (tests swap the delegate, not global.fetch itself).
+let currentFetchImpl = () => {
+  throw new Error('no fetch impl installed for this test');
+};
+global.fetch = (...args) => currentFetchImpl(...args);
+
+const originalLoad = Module._load;
+Module._load = function (request, parent, isMain) {
+  if (request === 'node_helper') {
+    return {
+      create(definition) {
+        return definition;
+      }
+    };
+  }
+  return originalLoad.apply(this, arguments);
+};
+
+let helperDefinition;
+try {
+  helperDefinition = require('../node_helper');
+} finally {
+  Module._load = originalLoad;
+}
+
+function createHelper() {
+  return Object.assign(Object.create(helperDefinition), {
+    config: { timeZone: 'America/Chicago' },
+    sent: [],
+    _lastGoodByLeague: {},
+    sendSocketNotification(notification, payload) {
+      this.sent.push({ notification, payload });
+    }
+  });
+}
+
+const sampleFinalGame = {
+  gamePk: 111111,
+  gameDate: '2026-07-29T23:10:00Z',
+  status: { abstractGameState: 'Final', detailedState: 'Final', codedGameState: 'F' },
+  teams: {
+    away: { score: 3, team: { id: 112, name: 'Chicago Cubs' } },
+    home: { score: 5, team: { id: 158, name: 'Milwaukee Brewers' } }
+  },
+  linescore: {
+    currentInning: 9,
+    currentInningOrdinal: '9th',
+    inningState: 'Top',
+    scheduledInnings: 9,
+    innings: [],
+    teams: { away: { runs: 3, hits: 7, errors: 1 }, home: { runs: 5, hits: 9, errors: 0 } }
+  }
+};
+
+test('a failing international/WBC sportId does not wipe out a successful primary MLB fetch', async () => {
+  const helper = createHelper();
+
+  currentFetchImpl = async (url) => {
+    if (url.includes('sportId=51')) {
+      return { ok: false, status: 503, statusText: 'Service Unavailable', headers: {}, text: async () => '', json: async () => ({}) };
+    }
+    const body = JSON.stringify({ dates: [{ date: '2026-07-30', games: [sampleFinalGame] }] });
+    return { ok: true, status: 200, statusText: 'OK', headers: {}, text: async () => body, json: async () => JSON.parse(body) };
+  };
+
+  await helper._fetchMlbGames();
+
+  const mlbNotification = helper.sent.find((s) => s.payload.league === 'mlb');
+  assert.ok(mlbNotification, 'expected an mlb GAMES notification');
+  assert.equal(mlbNotification.payload.games.length, 1);
+  assert.equal(mlbNotification.payload.games[0].gamePk, 111111);
+  assert.equal(mlbNotification.payload.isStale, undefined);
+  assert.equal(mlbNotification.payload.errorMessage, undefined);
+});
+
+test('a failing primary MLB sportId still surfaces as an error/fallback', async () => {
+  const helper = createHelper();
+
+  currentFetchImpl = async (url) => {
+    if (url.includes('sportId=1&')) {
+      return { ok: false, status: 500, statusText: 'Internal Server Error', headers: {}, text: async () => '', json: async () => ({}) };
+    }
+    const body = JSON.stringify({ dates: [] });
+    return { ok: true, status: 200, statusText: 'OK', headers: {}, text: async () => body, json: async () => JSON.parse(body) };
+  };
+
+  await helper._fetchMlbGames();
+
+  const mlbNotification = helper.sent.find((s) => s.payload.league === 'mlb');
+  assert.ok(mlbNotification, 'expected an mlb GAMES notification');
+  assert.equal(mlbNotification.payload.games.length, 0);
+  assert.match(mlbNotification.payload.errorMessage, /sportId=1/);
+});


### PR DESCRIPTION
## Summary
This change improves the resilience of MLB game fetching by allowing failures in secondary sports feeds (like international/WBC games) to not wipe out successful primary MLB feed data. Only failures of the primary MLB feed are now treated as fatal errors.

## Key Changes
- **New `_fetchMlbGamesForDate()` method**: Replaces direct `Promise.all()` calls with `Promise.allSettled()` to handle individual feed failures independently. This method:
  - Fetches all configured MLB sport IDs in parallel
  - Aggregates successful results while logging warnings for failures
  - Only throws an error if the primary sport ID (index 0) fails
  - Allows secondary feeds (e.g., WBC/international) to fail without affecting primary MLB data

- **Updated `_fetchMlbGames()` method**: Refactored to use the new `_fetchMlbGamesForDate()` helper for both display and schedule game fetching, reducing code duplication

- **Comprehensive test coverage**: Added `mlb-partial-feed-failure.test.js` with two test cases:
  - Verifies that a failing international/WBC feed doesn't prevent successful MLB game data from being sent
  - Verifies that a failing primary MLB feed still surfaces as an error with appropriate fallback behavior

- **Added `.gitignore`**: Standard Node.js ignore file for `node_modules/`

## Implementation Details
The solution uses `Promise.allSettled()` instead of `Promise.all()` to prevent one rejected promise from failing the entire operation. Each sport ID fetch is evaluated independently, with failures logged as warnings. The primary sport ID (MLB) is special-cased to maintain backward compatibility—if it fails, the error is re-thrown to trigger existing error handling logic.

https://claude.ai/code/session_015fegnCDoQ8769MgBstfvMS