### PR TITLE
Align "Today's Schedule" text based on module placement

### DIFF
--- a/MMM-Scores.css
+++ b/MMM-Scores.css
@@ -746,3 +746,20 @@
 .scoreboard-round-label-right {
   text-align: right;
 }
+
+.schedule-title {
+  width: min(100%, var(--scoreboard-content-width, 100%));
+  text-align: center;
+}
+
+.schedule-title-left {
+  text-align: left;
+}
+
+.schedule-title-center {
+  text-align: center;
+}
+
+.schedule-title-right {
+  text-align: right;
+}

--- a/MMM-Scores.js
+++ b/MMM-Scores.js
@@ -1471,7 +1471,8 @@
       if (pageGames && pageGames.length > 0) {
         if (isSchedulePage) {
           var scheduleTitle = document.createElement("div");
-          scheduleTitle.className = "small dimmed";
+          var scheduleAlignment = this._placementAlignment || this._detectPlacementAlignment(false) || "center";
+          scheduleTitle.className = "small dimmed schedule-title schedule-title-" + scheduleAlignment;
           scheduleTitle.innerText = "Today's Schedule";
           container.appendChild(scheduleTitle);
         }


### PR DESCRIPTION
## Summary
- Right-justify the "Today's Schedule" label when the module is placed on the right
- Center-justify it when the module is placed in a middle section
- Left-justify it when the module is placed on the left
- Reuses the existing placement-detection logic (`_placementAlignment` / `_detectPlacementAlignment`) that already drives alignment for the World Cup round label

## Test plan
- [ ] Load the module in `top_left`/`bottom_left` region and confirm "Today's Schedule" is left-justified
- [ ] Load the module in `top_center`/`middle_center` region and confirm it's centered
- [ ] Load the module in `top_right`/`bottom_right` region and confirm it's right-justified


---
_Generated by [Claude Code](https://claude.ai/code/session_01C7zhnkop182VcVw3D2vfZ3)_